### PR TITLE
Remove reference to grokengine-default.xml config file, not relevant to ...

### DIFF
--- a/py/nupic/support/configuration_base.py
+++ b/py/nupic/support/configuration_base.py
@@ -420,7 +420,6 @@ class Configuration(object):
 
     # Default one first
     cls.readConfigFile('nupic-default.xml')
-    cls.readConfigFile('grokengine-default.xml')
 
     # Site specific one can override properties defined in default
     cls.readConfigFile('nupic-site.xml')

--- a/py/nupic/support/configuration_custom.py
+++ b/py/nupic/support/configuration_custom.py
@@ -116,7 +116,7 @@ class Configuration(ConfigurationBase):
 
     # Clear the in-memory settings cache, forcing reload upon subsequent "get"
     # request.
-    super(cls, cls).clear()
+    super(Configuration, cls).clear()
 
     # Delete the persistent custom configuration store and reset in-memory
     # custom configuration info
@@ -140,7 +140,7 @@ class Configuration(ConfigurationBase):
     """ Intercept the _readStdConfigFiles call from our base config class to
     read in base and custom configuration settings.
     """
-    super(cls, cls)._readStdConfigFiles()
+    super(Configuration, cls)._readStdConfigFiles()
 
     cls.loadCustomConfig()
 


### PR DESCRIPTION
...NuPIC, reverting 24b16d61594b5125471bd6eb061b089abdaf19c7 in the process.  Fix super() calls in py/nupic/support/configuration_custom.py
