### PR TITLE
Link to JIRA issue tracker in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ NuPIC is a library that provides the building blocks for online prediction syste
 
 For more information, see [numenta.org](http://numenta.org).
 
+Issue tracker at [issues.numenta.org](https://issues.numenta.org/browse/NPC).
+
 OPF Basics
 ----------
 


### PR DESCRIPTION
Since GitHub issues is disabled, there needs to be a more prominent link to issues.numenta.org in the GitHub page.
