### PR TITLE
Funky character in plain-text Contributor License Agreement

### DIFF
--- a/licenses/cl/numenta-cl.txt
+++ b/licenses/cl/numenta-cl.txt
@@ -39,7 +39,7 @@ copy for your records.
   (optional) notify project: ______________________________________
 
 
- 
+
 Terms and Conditions
 
 You accept and agree to the following terms and conditions for Your


### PR DESCRIPTION
Should address that odd-looking     â€ƒ above "Terms and Conditions" visible at http://www.diffchecker.com/tas54ez4
