### PR TITLE
remove gcc flag -Wnewline-eof on Mac

### DIFF
--- a/build_system/unix/configure.ac
+++ b/build_system/unix/configure.ac
@@ -119,7 +119,7 @@ AC_MSG_CHECKING([platform])
 case "${target}" in
      *darwin*)
         nta_platform="darwin64"
-        nta_platform_cxxflags="-fPIC -DPIC -Wnewline-eof -m64"
+        nta_platform_cxxflags="-fPIC -DPIC -m64"
         # link against the system version of python (64-bits)
         nta_platform_python_libs="-F/System/Library/Frameworks -framework Python"
         nta_platform_env1="MACOSX_DEPLOYMENT_TARGET=10.7"


### PR DESCRIPTION
this is an unstandard flag, causing us problems on newer versions of Apple's GCC
(4.2 was fine, 4.7 was causing errors)

see https://github.com/joyent/node/pull/3887
and ML discussion titled "[nupic-dev] Building in OS X 10.6.8"
