### PR TITLE
along with asteval 0.9.1 update, unittest must update too

### DIFF
--- a/tests/external/py2/asteval_test.py
+++ b/tests/external/py2/asteval_test.py
@@ -31,7 +31,7 @@ class TestCase(unittest.TestCase):
 
   def testImportAndVersions(self):
     import asteval
-    self.assertEqual(asteval.__version__, '0.9')
+    self.assertEqual(asteval.__version__, '0.9.1')
 
 
 


### PR DESCRIPTION
small check, bump minor version number.
PS: do we really need this check, as asteval is installed by pip anyway? This will cause pain on any future update.
