### PR TITLE
Update xcode-setup-install.py

### DIFF
--- a/build_system/contrib/xcode-setup-install.py
+++ b/build_system/contrib/xcode-setup-install.py
@@ -21,8 +21,8 @@ if retCode != 0:
   print >>sys.stderr, 'setup.py failed: Error', retCode
   sys.exit(1)
 
-buildDir = os.environ['BUILT_PRODUCTS_DIR']
-buildStyle = os.environ['BUILD_STYLE']
+buildDir = os.environ['BUILDDIR']
+buildStyle = 'debug'
 
 # Build the configure command.
 configureCmd = os.path.join(buildSystemDir, 'contrib', 'configure.py')


### PR DESCRIPTION
Fixed environment variables (buildStyle don't exists). 

Note: single quotes are everywhere.
