### PR TITLE
Revert to using --target option for pip to explicitly install to lib/

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -67,10 +67,10 @@ function pythonSetup {
   # Workaround for matplotlib install bug: numpy must already be installed
   # see http://stackoverflow.com/questions/11797688/matplotlib-requirements-with-pip-install-in-virtualenv
   # https://github.com/matplotlib/matplotlib/wiki/MEP11
-  PATH=$NUPIC_INSTALL:$PATH pip install --find-links=file://$NUPIC/external/common/pip-cache --no-index --index-url=file:///dev/null --install-option="--prefix=$NUPIC_INSTALL" numpy==1.7.1
+  PATH=$NUPIC_INSTALL:$PATH pip install --find-links=file://$NUPIC/external/common/pip-cache --no-index --index-url=file:///dev/null --target=$NUPIC_INSTALL/lib/python${PY_VER}/site-packages --install-option="--install-scripts=$NUPIC_INSTALL/bin" numpy==1.7.1
   exitOnError $?
 
-  PATH=$NUPIC_INSTALL:$PATH pip install --find-links=file://$NUPIC/external/common/pip-cache --no-index --index-url=file:///dev/null --install-option="--prefix=$NUPIC_INSTALL" -r $NUPIC/external/common/requirements.txt
+  PATH=$NUPIC_INSTALL:$PATH pip install --find-links=file://$NUPIC/external/common/pip-cache --no-index --index-url=file:///dev/null --target=$NUPIC_INSTALL/lib/python${PY_VER}/site-packages --install-option="--install-scripts=$NUPIC_INSTALL/bin" -r $NUPIC/external/common/requirements.txt
   exitOnError $?
   # cov-core may fail to install properly, reporting something to the effect of:
   #


### PR DESCRIPTION
This is an interim fix for internal build problems related to conflicting lib/lib64 paths.
