### PR TITLE
Remove --target (again) in favor of specifying --install-lib

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -67,10 +67,10 @@ function pythonSetup {
   # Workaround for matplotlib install bug: numpy must already be installed
   # see http://stackoverflow.com/questions/11797688/matplotlib-requirements-with-pip-install-in-virtualenv
   # https://github.com/matplotlib/matplotlib/wiki/MEP11
-  PATH=$NUPIC_INSTALL:$PATH pip install --find-links=file://$NUPIC/external/common/pip-cache --no-index --index-url=file:///dev/null --install-option="--install-scripts=$NUPIC_INSTALL/bin" --install-option="--install-lib=$NUPIC_INSTALL/lib" numpy==1.7.1
+  PATH=$NUPIC_INSTALL:$PATH pip install --find-links=file://$NUPIC/external/common/pip-cache --no-index --index-url=file:///dev/null --install-option="--install-scripts=$NUPIC_INSTALL/bin" --install-option="--install-lib=$NUPIC_INSTALL/lib/python${PY_VER}/site-packages" numpy==1.7.1
   exitOnError $?
 
-  PATH=$NUPIC_INSTALL:$PATH pip install --find-links=file://$NUPIC/external/common/pip-cache --no-index --index-url=file:///dev/null --install-option="--install-scripts=$NUPIC_INSTALL/bin" --install-option="--install-lib=$NUPIC_INSTALL/lib" -r $NUPIC/external/common/requirements.txt
+  PATH=$NUPIC_INSTALL:$PATH pip install --find-links=file://$NUPIC/external/common/pip-cache --no-index --index-url=file:///dev/null --install-option="--install-scripts=$NUPIC_INSTALL/bin" --install-option="--install-lib=$NUPIC_INSTALL/lib/python${PY_VER}/site-packages" -r $NUPIC/external/common/requirements.txt
   exitOnError $?
   # cov-core may fail to install properly, reporting something to the effect of:
   #


### PR DESCRIPTION
This is a follow-up to https://github.com/numenta/nupic/pull/197

As it turns out, if you specify --target, pip assumes you're installing a pure-python lib, and makes some assumptions about where to clean up that may be wrong in some circumstances.  This PR removes the --target option in favor of --install-lib (specified via --install-option) and appears to do the right thing in our internal build environment.
