### PR TITLE
Add support for sparsity normalization

### DIFF
--- a/py/nupic/encoders/bitmaparray.py
+++ b/py/nupic/encoders/bitmaparray.py
@@ -21,6 +21,7 @@
 
 from base import *
 from nupic.data.fieldmeta import FieldMetaType
+import random
 
 ############################################################################
 class BitmapArrayEncoder(Encoder):
@@ -37,7 +38,7 @@ class BitmapArrayEncoder(Encoder):
   """
 
   ############################################################################
-  def __init__(self, n, w, name="bitmaparray", verbosity=0):
+  def __init__(self, n, w, onbits=0, name="bitmaparray", verbosity=0):
     """
     n is the total bits in input
     w is the number of bits used to encode each input bit
@@ -45,6 +46,7 @@ class BitmapArrayEncoder(Encoder):
 
     self.n = n
     self.w = w
+    self.onbits = onbits
     self.verbosity = verbosity
     self.description = [(name, 0)]
     self.name = name
@@ -82,6 +84,23 @@ class BitmapArrayEncoder(Encoder):
     for i in input:
       for j in xrange(0,self.w):
         output[(int(i)*self.w)+j] = 1
+
+    if self.onbits > 0:
+      random.seed(hash(str(output)))
+      t = self.onbits - output.sum()
+      while t > 0:
+        """ turn on more bits to normalize """
+        i = random.randint(0,self.n-1)
+        if output[i] == 0:
+          output[i] = 1
+          t -= 1
+
+      while t < 0:
+        """ turn off some bits to normalize """
+        i = random.randint(0,self.n-1)
+        if output[i] == 1:
+          output[i] = 0
+          t += 1
 
     if self.verbosity >= 2:
       print "input:", input, "index:", index, "output:", output

--- a/tests/unit/py2/nupic/encoders/bitmaparray_test.py
+++ b/tests/unit/py2/nupic/encoders/bitmaparray_test.py
@@ -45,13 +45,13 @@ class BitmapArrayEncoderTest(unittest.TestCase):
 
 
   def testInitialization(self):
-    e = self._encoder(self.n, self.w, self.name)
+    e = self._encoder(self.n, self.w, name=self.name)
     self.assertEqual(type(e), self._encoder)
 
 
   def testEncodeString(self):
     """Send array as csv string."""
-    e = self._encoder(self.n, self.w, self.name)
+    e = self._encoder(self.n, self.w, name=self.name)
     bitmap = "2,7,15,18,23"
     out = e.encode(bitmap)
     assert out.sum() == len(bitmap.split(','))*self.w
@@ -63,7 +63,7 @@ class BitmapArrayEncoderTest(unittest.TestCase):
 
   def testEncodeArray(self):
     """Send bitmap as array of indicies"""
-    e = self._encoder(self.n, self.w, self.name)
+    e = self._encoder(self.n, self.w, name=self.name)
     bitmap = [2,7,15,18,23]
     out = e.encode(bitmap)
     assert out.sum() == len(bitmap)*self.w
@@ -75,7 +75,7 @@ class BitmapArrayEncoderTest(unittest.TestCase):
 
   def testClosenessScores(self):
     """Compare two bitmaps for closeness"""
-    e = self._encoder(self.n, self.w, self.name)
+    e = self._encoder(self.n, self.w, name=self.name)
 
     """Identical => 1"""
     bitmap1 = [2,7,15,18,23]
@@ -133,6 +133,25 @@ class BitmapArrayEncoderTest(unittest.TestCase):
     self.testEncodeString()
     self.testEncodeArray()
     self.testClosenessScores()
+
+
+  def testSparsity(self):
+    """Set sparsity nomalization"""
+    self.n = 25
+    self.w = 1
+    self.onbits = 5
+    e = self._encoder(self.n, self.w, self.onbits, self.name)
+    bitmap = [2,7,15,18,23]
+    out = e.encode(bitmap)
+    assert out.sum() == self.onbits
+
+    bitmap = [2]
+    out = e.encode(bitmap)
+    assert out.sum() == self.onbits
+
+    bitmap = [0,1,2,3,7,15,18,23]
+    out = e.encode(bitmap)
+    assert out.sum() == self.onbits
 
 
 

--- a/tests/unit/py2/nupic/encoders/passthru_test.py
+++ b/tests/unit/py2/nupic/encoders/passthru_test.py
@@ -45,13 +45,13 @@ class PassThruEncoderTest(unittest.TestCase):
 
 
   def testInitialization(self):
-    e = self._encoder(self.n, self.w, self.name)
+    e = self._encoder(self.n, self.w, name=self.name)
     self.assertEqual(type(e), self._encoder)
 
 
   def testEncodeArray(self):
     """Send bitmap as array"""
-    e = self._encoder(self.n, self.w, self.name)
+    e = self._encoder(self.n, self.w, name=self.name)
     bitmap = [0,0,0,1,0,0,0,0,0]
     out = e.encode(bitmap)
     assert out.sum() == sum(bitmap)*self.w
@@ -63,7 +63,7 @@ class PassThruEncoderTest(unittest.TestCase):
 
   def testEncodeBitArray(self):
     """Send bitmap as numpy bit array"""
-    e = self._encoder(self.n, self.w, self.name)
+    e = self._encoder(self.n, self.w, name=self.name)
     bitmap = numpy.zeros(self.n, dtype=numpy.uint8)
     bitmap[3] = 1
     bitmap[5] = 1
@@ -73,7 +73,7 @@ class PassThruEncoderTest(unittest.TestCase):
 
   def testClosenessScores(self):
     """Compare two bitmaps for closeness"""
-    e = self._encoder(self.n, self.w, self.name)
+    e = self._encoder(self.n, self.w, name=self.name)
 
     """Identical => 1"""
     bitmap1 = [0,0,0,1,1,1,0,0,0]
@@ -131,6 +131,25 @@ class PassThruEncoderTest(unittest.TestCase):
     self.testEncodeArray()
     self.testEncodeBitArray()
     self.testClosenessScores()
+
+
+  def testSparsity(self):
+    """Set sparsity nomalization"""
+    self.n = 9 
+    self.w = 1
+    self.onbits = 3
+    e = self._encoder(self.n, self.w, self.onbits, self.name)
+    bitmap = [0,0,0,1,0,0,0,1,1]
+    out = e.encode(bitmap)
+    assert out.sum() == self.onbits
+
+    bitmap = [1,0,0,0,0,0,0,0,0]
+    out = e.encode(bitmap)
+    assert out.sum() == self.onbits
+
+    bitmap = [1,1,1,1,0,0,0,0,0]
+    out = e.encode(bitmap)
+    assert out.sum() == self.onbits
 
 
 


### PR DESCRIPTION
These changes allow a set sparsity to be declared in the constructor by setting the optional 'onbits' fields.  The desired sparsity is achieved by activating or deactivating random bits in the output until the target sparsity is achieved.  The random number generator is seeded with the hash of the input bitmap to ensure consistent results with the same input.
