### PR TITLE
Small capitilization text fix on new Code-of-conduct page.

### DIFF
--- a/_includes/content/code-of-conduct.md
+++ b/_includes/content/code-of-conduct.md
@@ -1,7 +1,7 @@
 Numenta Event Anti-Harassment Policy
 ====================================
 
-Numenta is dedicated to providing a harassment-free event experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religious preferences. We do not tolerate harassment of event participants in any form. Sexual language and imagery is not appropriate for any event venue, including talks. event participants violating these rules may be sanctioned or expelled from the event without a refund at the discretion of the event organizers.
+Numenta is dedicated to providing a harassment-free event experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religious preferences. We do not tolerate harassment of event participants in any form. Sexual language and imagery is not appropriate for any event venue, including talks. Event participants violating these rules may be sanctioned or expelled from the event without a refund at the discretion of the event organizers.
 
 Harassment includes offensive verbal comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religious preferences, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
 


### PR DESCRIPTION
"... talks. event participants ..." 

=> 

"... talks. Event participants ..."
