### PR TITLE
Pass thru  encoder fixes

### DIFF
--- a/py/nupic/encoders/passthru.py
+++ b/py/nupic/encoders/passthru.py
@@ -49,6 +49,7 @@ class PassThruEncoder(Encoder):
     self.verbosity = verbosity
     self.description = [(name, 0)]
     self.name = name
+    self.forced = forced
 
   ############################################################################
   def getDecoderOutputFieldTypes(self):
@@ -77,16 +78,13 @@ class PassThruEncoder(Encoder):
   ############################################################################
   def encodeIntoArray(self, input, output):
     """ See method description in base.py """
-    if forced:
+    if self.forced:
       return input # total identity
 
-    o = []
-    for v in input:
-      tmp = [v]*self.m
-      o.append(tmp[:])
+    if len(input)*self.m != len(output):
+      raise Exception("Wrong input size")
 
-    print "o=",o,"typ",type(o), type(output)
-    output[:]=numpy.array(o)
+    output[:]=numpy.repeat(input, self.m).tolist()
 
     if self.w is not None: # require w bits ON sparsity in SDR
       random.seed(hash(str(output)))

--- a/tests/unit/py2/nupic/encoders/passthru_test.py
+++ b/tests/unit/py2/nupic/encoders/passthru_test.py
@@ -64,11 +64,14 @@ class PassThruEncoderTest(unittest.TestCase):
   def testEncodeBitArray(self):
     """Send bitmap as numpy bit array"""
     e = self._encoder(self.n, multiply=self.m, name=self.name)
-    bitmap = numpy.zeros(self.n, dtype=numpy.uint8)
+    bitmap = numpy.zeros(self.n/self.m, dtype=numpy.uint8)
     bitmap[3] = 1
     bitmap[5] = 1
     out = e.encode(bitmap)
-    self.assertEqual(out.sum(), sum(bitmap)*self.m)
+    sum_expected = sum(bitmap)*self.m
+    sum_real = out.sum()
+    print "bitmap=", bitmap, "out=", out
+    self.assertEqual(sum_real, sum_expected)
 
 
   def testClosenessScores(self):
@@ -125,7 +128,7 @@ class PassThruEncoderTest(unittest.TestCase):
 
 
   def testRobustness(self):
-    """Encode bitmaps with robustness (w) set"""
+    """Encode bitmaps with robustness (m) set"""
     self.n = 27 
     self.m = 3
     self.testEncodeArray()


### PR DESCRIPTION
Fixes to pass through encoder; 

rename parameters according to naming conventions (w=#ONbits, etc..), 
fix a bug where different patterns would produce outputs of different lengths!, 
allow forced mode, which is real pass-thru only, it does directly return the input from encode (so the input can be python list with arbitrary elements, on the contrary with decoding to numpy.array output, where all elements must be numbers!)--this is useful for some usecases this encoder was intended for. 

other cleanup,speedup. 

This encoder wasn't likely used (because of the bugs discovered now), so please merge quickly, I'd like to depend on it. 

Thank you, breznak
