### PR TITLE
Restore travis config, using TRAVIS_BUILD_DIR directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "2.7"
 env:
   global:
-    - NUPIC=$PWD/$TRAVIS_REPO_SLUG
+    - NUPIC=$TRAVIS_BUILD_DIR
     - NTA=$HOME/nta/eng
 
     # For S3 upload from travis-artifacts


### PR DESCRIPTION
"The fix for this has been rolled out, let us know if you're still seeing any issues!" </snip>

Revert "Derive $NUPIC from $PWD and $TRAVIS_REPO_SLUG as https://github.com/travis-ci/travis-build/pull/182 may not be deployed yet"

This reverts commit 65ba48645eb29f64062679646a8b8335c4af1026.
