### PR TITLE
Clamodel.py cleanup

### DIFF
--- a/py/nupic/frameworks/opf/clamodel.py
+++ b/py/nupic/frameworks/opf/clamodel.py
@@ -121,9 +121,9 @@ class CLAModel(Model):
       sensorParams={},
       spEnable=True,
       spParams={},
-      
+
       # TODO: We can't figure out what this is. Remove?
-      trainSPNetOnlyIfRequested=False,  
+      trainSPNetOnlyIfRequested=False,
       tpEnable=True,
       tpParams={},
       clParams={},
@@ -181,7 +181,7 @@ class CLAModel(Model):
     # enable/disable//SP/TP//Learning methods)
     self.__spLearningEnabled = bool(spEnable)
     self.__tpLearningEnabled = bool(tpEnable)
-    
+
     # Explicitly exclude the TP if this type of inference doesn't require it
     if not InferenceType.isTemporal(self.getInferenceType()) \
        or self.getInferenceType() is InferenceType.NontemporalMultiStep:
@@ -190,7 +190,7 @@ class CLAModel(Model):
     self._netInfo = None
     self._hasSP = spEnable
     self._hasTP = tpEnable
-    
+
     self._classifierInputEncoder = None
     self._predictedFieldIdx = None
     self._predictedFieldName = None
@@ -400,13 +400,13 @@ class CLAModel(Model):
     inferences = {}
 
     # TODO: Reconstruction and temporal classification not used. Remove
-    if self._isReconstructionModel():  
+    if self._isReconstructionModel():
       inferences = self._reconstructionCompute()
       tpTopDownComputed = True
     elif self._isMultiStepModel():
       inferences = self._multiStepCompute(rawInput=inputRecord)
     # For temporal classification. Not used, and might not work anymore
-    elif self._isClassificationModel():  
+    elif self._isClassificationModel():
       inferences = self._classifcationCompute()
 
     results.inferences.update(inferences)
@@ -436,7 +436,7 @@ class CLAModel(Model):
   def _getSensorInputRecord(self, inputRecord):
     """
     inputRecord - dict containing the input to the sensor
-    
+
     Return a 'SensorInput' object, which represents the 'parsed'
     representation of the input record
     """
@@ -613,7 +613,7 @@ class CLAModel(Model):
   def _anomalyCompute(self, computeTPTopDown):
     """
     Compute Anomaly score, if required
-      computeTPTopDown: If True, first perform a  
+      computeTPTopDown: If True, first perform a
 
     """
     inferenceType = self.getInferenceType()
@@ -685,7 +685,7 @@ class CLAModel(Model):
                   each time unless there are missing records. If there is no
                   aggregation interval or timestamp in the data, this will be
                   None.
-    rawInput:   The raw input to the sensor, as a dict. 
+    rawInput:   The raw input to the sensor, as a dict.
     """
 
     sensor = self._getSensorRegion()
@@ -703,7 +703,7 @@ class CLAModel(Model):
         raise RuntimeError("This experiment description is missing "
               "the 'predictedField' in its config, which is required "
               "for multi-step prediction inference.")
-      
+
       # This is getting index of predicted field if being fed to CLA.
       self._predictedFieldName = predictedFieldName
       encoderList = sensor.getSelf().encoder.getEncoderList()
@@ -714,15 +714,15 @@ class CLAModel(Model):
       else:
         # Predicted field was not fed into the network, only to the classifier
         self._predictedFieldIdx = None
-      
-      # In a multi-step model, the classifier input encoder is separate from 
-      #  the other encoders and always disabled from going into the bottom of 
+
+      # In a multi-step model, the classifier input encoder is separate from
+      #  the other encoders and always disabled from going into the bottom of
       # the network.
       if sensor.getSelf().disabledEncoder is not None:
         encoderList = sensor.getSelf().disabledEncoder.getEncoderList()
       else:
         encoderList = []
-      if len(encoderList) >= 1:  
+      if len(encoderList) >= 1:
         fieldNames = sensor.getSelf().disabledEncoder.getScalarNames()
         self._classifierInputEncoder = encoderList[fieldNames.index(
                                                         predictedFieldName)]
@@ -731,8 +731,8 @@ class CLAModel(Model):
         #  classifier, so use the one that goes into the bottom of the network
         encoderList = sensor.getSelf().encoder.getEncoderList()
         self._classifierInputEncoder = encoderList[self._predictedFieldIdx]
-        
-        
+
+
 
     # Get the actual value and the bucket index for this sample. The
     #  predicted field may not be enabled for input to the network, so we
@@ -740,7 +740,7 @@ class CLAModel(Model):
     # TODO: All this logic could be simpler if in the encoder itself
     absoluteValue = rawInput[predictedFieldName]
     bucketIdx = self._classifierInputEncoder.getBucketIndices(absoluteValue)[0]
-    
+
     # Convert the absolute values to deltas if necessary
     # The bucket index should be handled correctly by the underlying delta encoder
     if self._classifierInputEncoder.isDelta():
@@ -766,7 +766,7 @@ class CLAModel(Model):
     classifier.setParameter('learningMode', needLearning)
     classificationIn = {'bucketIdx': bucketIdx,
                         'actValue': actualValue}
-    
+
     # Handle missing records
     if inputTSRecordIdx is not None:
       recordNum = inputTSRecordIdx
@@ -856,7 +856,7 @@ class CLAModel(Model):
         # Get the prediction history for this number of timesteps.
         # The prediction history is a store of the previous best predicted values.
         # This is used to get the final shift from the current absolute value.
-        if not hasattr(self,'_ms_predHistories'):
+        if not hasattr(self, '_ms_predHistories'):
           self._ms_predHistories = dict()
         predHistories = self._ms_predHistories
         if not steps in predHistories:
@@ -973,7 +973,7 @@ class CLAModel(Model):
     fieldNames = encoder.getScalarNames()
     fieldTypes = encoder.getDecoderOutputFieldTypes()
     assert len(fieldNames) == len(fieldTypes)
-    
+
     # Also include the classifierOnly field?
     encoder = self._getClassifierOnlyEncoder()
     if includeClassifierOnlyField and encoder is not None:
@@ -1079,24 +1079,24 @@ class CLAModel(Model):
     sensor = n.regions['sensor'].getSelf()
 
     enabledEncoders = copy.deepcopy(sensorParams['encoders'])
-    for name,params in enabledEncoders.items():
+    for name, params in enabledEncoders.items():
       if params is not None:
-        classifierOnly = params.pop('classifierOnly', False)  
+        classifierOnly = params.pop('classifierOnly', False)
         if classifierOnly:
           enabledEncoders.pop(name)
-      
+
     # Disabled encoders are encoders that are fed to CLAClassifierRegion but not
     # SP or TP Regions. This is to handle the case where the predicted field
     # is not fed through the SP/TP. We typically just have one of these now.
     disabledEncoders = copy.deepcopy(sensorParams['encoders'])
-    for name,params in disabledEncoders.items():
+    for name, params in disabledEncoders.items():
       if params is None:
         disabledEncoders.pop(name)
       else:
         classifierOnly = params.pop('classifierOnly', False)
         if not classifierOnly:
           disabledEncoders.pop(name)
-        
+
     encoder = MultiEncoder(enabledEncoders)
 
     sensor.encoder = encoder
@@ -1107,7 +1107,7 @@ class CLAModel(Model):
     # at a regular interval, such as every week for daily data, every day for
     # hourly data, etc.
     # TODO: remove, not being used anymore
-    if sensorParams['sensorAutoReset']: 
+    if sensorParams['sensorAutoReset']:
       sensorAutoResetDict = sensorParams['sensorAutoReset']
 
       supportedUnits = set(('days', 'hours', 'minutes', 'seconds',
@@ -1157,7 +1157,7 @@ class CLAModel(Model):
       n.link("sensor", "SP", "UniformLink", "")
       n.link("sensor", "SP", "UniformLink", "", srcOutput="resetOut",
              destInput="resetIn")
-      
+
       n.link("SP", "sensor", "UniformLink", "", srcOutput="spatialTopDownOut",
              destInput="spatialTopDownIn")
       n.link("SP", "sensor", "UniformLink", "", srcOutput="temporalTopDownOut",
@@ -1221,7 +1221,7 @@ class CLAModel(Model):
     # it goes along. The concept is very useful for debugging but not used
     # anymore.
     # TODO: remove, including NetworkInfo, DutyCycleStatistic, CLAStatistic
-    
+
     #--------------------------------------------------
     # Create stats collectors for this network
     #
@@ -1302,16 +1302,16 @@ class CLAModel(Model):
       self._Model__inferenceArgs = {}
       self._Model__learningEnabled = True
       self._Model__inferenceEnabled = True
-      
+
       # Remove obsolete members
       self.__dict__.pop("_CLAModel__encoderNetInfo", None)
       self.__dict__.pop("_CLAModel__nonTemporalNetInfo", None)
       self.__dict__.pop("_CLAModel__temporalNetInfo", None)
-      
 
-      
+
+
     # -----------------------------------------------------------------------
-    # Migrate from v2 
+    # Migrate from v2
     if not hasattr(self, "_netInfo"):
       self._hasSP = False
       self._hasTP = False
@@ -1324,7 +1324,7 @@ class CLAModel(Model):
         self._netInfo = self.__temporalNetInfo
         self._hasSP = True
         self._hasTP = True
-      
+
       # Remove obsolete members
       self.__dict__.pop("_CLAModel__encoderNetInfo", None)
       self.__dict__.pop("_CLAModel__nonTemporalNetInfo", None)
@@ -1363,7 +1363,7 @@ class CLAModel(Model):
     self._netInfo.net.save(outputDir)
 
     self.__logger.info("Finished serializing network")
-    
+
     return
 
 
@@ -1398,7 +1398,7 @@ class CLAModel(Model):
     # NuPIC doesn't initialize the network until you try to run it
     # but users may want to access components in a setup callback
     self._netInfo.net.initialize()
-    
+
 
     # Used for backwards compatibility for anomaly classification models.
     # Previous versions used the CLAModelClassifierHelper class for utilizing
@@ -1420,15 +1420,15 @@ class CLAModel(Model):
         else:
           anomalyClParams['anomalyThreshold'] = (
             self._classifier_helper.getAutoDetectThreshold())
-        
-        spEnable = (self._getSPRegion() is not None)       
+
+        spEnable = (self._getSPRegion() is not None)
         tpEnable = True
-  
-        # Store original KNN region 
+
+        # Store original KNN region
         knnRegion = self._getAnomalyClassifier().getSelf()
-        
+
         # Add new KNNAnomalyClassifierRegion
-        self._addAnomalyClassifierRegion(self._netInfo.net, anomalyClParams, 
+        self._addAnomalyClassifierRegion(self._netInfo.net, anomalyClParams,
                                          spEnable, tpEnable)
 
         # Restore state
@@ -1436,7 +1436,7 @@ class CLAModel(Model):
         self._getAnomalyClassifier().getSelf()._recordsCache = (
             self._classifier_helper.saved_states)
         self._getAnomalyClassifier().getSelf().saved_categories = (
-            self._classifier_helper.saved_categories)        
+            self._classifier_helper.saved_categories)
         self._getAnomalyClassifier().getSelf()._knnclassifier = knnRegion
 
         # Set TP to output neccessary information
@@ -1466,9 +1466,9 @@ class CLAModel(Model):
     network - network to add the AnomalyClassifier region
     params - parameters to pass to the region
     spEnable - True if network has an SP region
-    tpEnable - True if network has a TP region; Currently requires True 
+    tpEnable - True if network has a TP region; Currently requires True
     """
-    
+
     allParams = copy.deepcopy(params)
     knnParams = dict(k=1,
                      distanceMethod='rawOverlap',


### PR DESCRIPTION
No functional changes.
- Use `is` for type comparison
- Rename `filter` local variable to `filter_` to avoid name conflict with builtin
- Use `for...else`
- Whitespace
