### PR TITLE
Improvements in TimerTest.cpp.

### DIFF
--- a/nta/os/unittests/TimerTest.cpp
+++ b/nta/os/unittests/TimerTest.cpp
@@ -24,7 +24,7 @@
  * @file
  */
 
-#define SLEEP_MICROSECONDS 100
+#define SLEEP_MICROSECONDS (100 * 1000)
 
 #include "TimerTest.hpp"
 #include <nta/utils/Log.hpp>


### PR DESCRIPTION
I realized a couple issues after some further reading: (1) apr_sleep() operates on microseconds, not milliseconds, and (2) microsecond accuracy cannot be guaranteed on Windows platforms.  To address (1) I have renamed the variable, and to address (2) I have increased the time from 100 microseconds to 100 milliseconds to ensure this Timer Test functions even if only millisecond accuracy is guaranteed.
