### PR TITLE
Added new SpatialPooler classes to SPRegion

### DIFF
--- a/examples/opf/clients/hotgym/model_params.py
+++ b/examples/opf/clients/hotgym/model_params.py
@@ -63,10 +63,6 @@ MODEL_PARAMS = {
                     'type': 'RandomDistributedScalarEncoder',
                     },
                     
-                'timestamp_dayOfWeek': {   'dayOfWeek': (21, 1),
-                                           'fieldname': u'timestamp',
-                                           'name': u'timestamp_dayOfWeek',
-                                           'type': 'DateEncoder'},
                 'timestamp_timeOfDay': {   'fieldname': u'timestamp',
                                            'name': u'timestamp_timeOfDay',
                                            'timeOfDay': (21, 1),
@@ -74,7 +70,8 @@ MODEL_PARAMS = {
                 'timestamp_weekend': {   'fieldname': u'timestamp',
                                          'name': u'timestamp_weekend',
                                          'type': 'DateEncoder',
-                                         'weekend': 21}},
+                                         'weekend': 21}
+                    },
 
             # A dictionary specifying the period for automatically-generated
             # resets from a RecordSensor;
@@ -99,8 +96,9 @@ MODEL_PARAMS = {
 
             # Spatial Pooler implementation selector, see getSPClass 
             # in py/regions/SPRegion.py for details
-            # 'py', 'oldpy' (default), 'cpp' (speed optimized, new)
-            'spatialImp' : 'cpp', 
+            # 'oldpy' (default, old), 'SpatialPooler' (C++, faster),
+            # 'PYSpatialPooler' (Python, slower)
+            'spatialImp' : 'SpatialPooler', 
 
             'globalInhibition': 1,
 
@@ -135,9 +133,9 @@ MODEL_PARAMS = {
             # is correct here as opposed to 'columns')
             'synPermConnected': 0.1,
 
-            'synPermActiveInc': 0.1,
+            'synPermActiveInc': 0.04,
 
-            'synPermInactiveDec': 0.01, 
+            'synPermInactiveDec': 0.005
         },
 
         # Controls whether TP is enabled or disabled;

--- a/py/regions/SPRegion.py
+++ b/py/regions/SPRegion.py
@@ -26,6 +26,8 @@ import os
 from nupic.bindings.math import GetNTAReal
 from nupic.research.FDRCSpatial2 import FDRCSpatial2
 from nupic.research.flat_spatial_pooler import FlatSpatialPooler as PyFlatSpatialPooler
+from nupic.bindings.algorithms import SpatialPooler as CPPSpatialPooler
+from nupic.research.spatial_pooler import SpatialPooler as PYSpatialPooler
 from nupic.bindings.algorithms import FlatSpatialPooler as CPPFlatSpatialPooler
 import nupic.research.fdrutilities as fdru
 from nupic.support import getArgumentDescriptions
@@ -51,9 +53,13 @@ def getSPClass(spatialImp):
     return CPPFlatSpatialPooler
   elif spatialImp == 'oldpy':
     return FDRCSpatial2
+  elif spatialImp == "SpatialPooler":
+    return CPPSpatialPooler
+  elif spatialImp == "PYSpatialPooler":
+    return PYSpatialPooler
   else:
     raise RuntimeError("Invalid spatialImp '%s'. Legal values are: 'py', "
-              "'cpp', and 'oldpy'" % (spatialImp))
+          "'cpp', 'oldpy', SpatialPooler, and PYSpatialPooler" % (spatialImp))
 
 ##############################################################################
 def _buildArgs(f, self=None, kwargs={}):
@@ -106,6 +112,15 @@ def _buildArgs(f, self=None, kwargs={}):
         argValue = argTuple[2]
       # Set as an instance variable if 'self' was passed in
       setattr(self, argName, argValue)
+      
+  # Translate some parameters for backward compatibility
+  if kwargs.has_key('numActivePerInhArea'):
+    setattr(self, 'numActiveColumnsPerInhArea', kwargs['numActivePerInhArea'])
+    kwargs.pop('numActivePerInhArea')
+    
+  if kwargs.has_key('coincInputPoolPct'):
+    setattr(self, 'potentialPct', kwargs['coincInputPoolPct'])
+    kwargs.pop('coincInputPoolPct')
 
   return argTuples
 
@@ -140,11 +155,15 @@ def _getAdditionalSpecs(spatialImp, kwargs={}):
     else:
       return ''
 
-  # Get arguments from FDRCSpatial2 constructor, figure out types of variables
-  # and populate spatialSpec
+  # Get arguments from spatial pooler constructors, figure out types of
+  # variables and populate spatialSpec. The old FDRCSpatialPooler and
+  # the new SpatialPooler classes have slightly different constructor argument
+  # names, so include them all as possible arguments.
   spatialSpec = {}
   FDRSpatialClass = getSPClass(spatialImp)
   sArgTuples = _buildArgs(FDRSpatialClass.__init__)
+  argTuplesNew = _buildArgs(CPPSpatialPooler.__init__)
+  sArgTuples.extend(argTuplesNew)
 
   for argTuple in sArgTuples:
     d = dict(
@@ -455,38 +474,53 @@ class SPRegion(PyRegion):
     # Retrieve the necessary extra arguments that were handled automatically
     autoArgs = dict((name, getattr(self, name))
                      for name in self._spatialArgNames)
-    autoArgs.pop('coincidencesShape')
-    autoArgs.pop('inputShape')
-    autoArgs.pop('inputBorder')
-    autoArgs.pop('coincInputRadius')
-    autoArgs.pop('cloneMap')
-    autoArgs.pop('numCloneMasters')
-
-    coincidencesShape = (self.columnCount, 1)
-    inputShape = (1, self.inputWidth)
-    inputBorder = inputShape[1]/2
-    if inputBorder*2 >= inputShape[1]:
-      inputBorder -= 1
-    coincInputRadius = inputShape[1]/2
-
-    cloneMap, numCloneMasters = fdru.makeCloneMap(
-        columnsShape=coincidencesShape,
-        outputCloningWidth=coincidencesShape[1],
-        outputCloningHeight=coincidencesShape[0]
+    
+    # Instantiate the spatial pooler class.
+    if ( (self._FDRCSpatialClass == CPPSpatialPooler) or
+         (self._FDRCSpatialClass == PYSpatialPooler) ):
+      
+      autoArgs['columnDimensions'] = [self.columnCount]
+      autoArgs['inputDimensions'] = [self.inputWidth]
+      autoArgs['potentialRadius'] = self.inputWidth
+    
+      self._sfdr = self._FDRCSpatialClass(
+        **autoArgs
       )
-
-    self._sfdr = self._FDRCSpatialClass(
-                              # These parameters are standard defaults for SPRegion
-                              # They can be overridden by explicit calls to
-                              # getParameter
-                              cloneMap=cloneMap,
-                              numCloneMasters=numCloneMasters,
-                              coincidencesShape=coincidencesShape,
-                              inputShape=inputShape,
-                              inputBorder=inputBorder,
-                              coincInputRadius = coincInputRadius,
-                              **autoArgs)
-
+      
+    else:
+      # Backward compatibility
+      autoArgs.pop('coincidencesShape')
+      autoArgs.pop('inputShape')
+      autoArgs.pop('inputBorder')
+      autoArgs.pop('coincInputRadius')
+      autoArgs.pop('cloneMap')
+      autoArgs.pop('numCloneMasters')
+  
+      coincidencesShape = (self.columnCount, 1)
+      inputShape = (1, self.inputWidth)
+      inputBorder = inputShape[1]/2
+      if inputBorder*2 >= inputShape[1]:
+        inputBorder -= 1
+      coincInputRadius = inputShape[1]/2
+  
+      cloneMap, numCloneMasters = fdru.makeCloneMap(
+          columnsShape=coincidencesShape,
+          outputCloningWidth=coincidencesShape[1],
+          outputCloningHeight=coincidencesShape[0]
+        )
+  
+      self._sfdr = self._FDRCSpatialClass(
+                                # These parameters are standard defaults for SPRegion
+                                # They can be overridden by explicit calls to
+                                # getParameter
+                                cloneMap=cloneMap,
+                                numCloneMasters=numCloneMasters,
+                                coincidencesShape=coincidencesShape,
+                                inputShape=inputShape,
+                                inputBorder=inputBorder,
+                                coincInputRadius = coincInputRadius,
+                                **autoArgs)
+  
 
   #############################################################################
   #


### PR DESCRIPTION
Added two new spatial pooler implementation options corresponding to the C++ and Python versions of the new Spatial Pooler classes. The OPF should now support the new spatial pooler.  The old class is still the default, but will change that soon.

Updated Hotgym to use the new class. Updated some of the Hotgym parameters to provide improved predictions. Related to Issue #340
