### PR TITLE
Confirms $NTA != $NUPIC within build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -118,7 +118,7 @@ function cleanUpEnv {
 mkdir -p `dirname $STDOUT`
 {
   checkEnv
-  exit
+
   syncCoreSubmodule
   prepDirectories
 


### PR DESCRIPTION
If they are the same, prints error message to stdout and exits.

fixes #655
