### PR TITLE
Potential fix for building with custom python installations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,7 +365,7 @@ string(REGEX REPLACE "\\\\" "/" PYTHON_PREFIX ${PYTHON_PREFIX})
 set(PYTHON_INCLUDE_DIR "${PYTHON_PREFIX}/include/python${PYTHON_VERSION}")
 set(PYTHON_LIBRARY_DIR "${PYTHON_PREFIX}/lib/python${PYTHON_VERSION}")
 set(PYTHON_SITE_PACKAGES_DIR "${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION}/site-packages")
-FIND_PACKAGE(PythonLibs REQUIRED)
+FIND_PACKAGE(PythonLibs ${PYTHON_VERSION} REQUIRED)
 
 #
 # Finds out version of Numpy and headers's path.


### PR DESCRIPTION
Ran into this problem in pursuit of numenta/nupic#708, which may also be affecting internal Grok testing pipelines.  The builds would pass, but the c++ binaries weren't properly linked to the python shared lib.

cc: @subutai @david-ragazzi 
