### PR TITLE
Added Classifier Implementation Parameter

### DIFF
--- a/examples/opf/clients/cpu/model_params.py
+++ b/examples/opf/clients/cpu/model_params.py
@@ -201,6 +201,9 @@ MODEL_PARAMS = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/clients/hotgym_anomaly/model_params.py
+++ b/examples/opf/clients/hotgym_anomaly/model_params.py
@@ -226,9 +226,11 @@ MODEL_PARAMS = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+
             'regionName' : 'CLAClassifierRegion',
-            
-            
+
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity

--- a/examples/opf/experiments/anomaly/spatial/10field_few2_skewed/description.py
+++ b/examples/opf/experiments/anomaly/spatial/10field_few2_skewed/description.py
@@ -282,6 +282,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/spatial/10field_few_skewed/description.py
+++ b/examples/opf/experiments/anomaly/spatial/10field_few_skewed/description.py
@@ -282,6 +282,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/spatial/10field_many_balanced/description.py
+++ b/examples/opf/experiments/anomaly/spatial/10field_many_balanced/description.py
@@ -282,6 +282,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/spatial/10field_many_skewed/description.py
+++ b/examples/opf/experiments/anomaly/spatial/10field_many_skewed/description.py
@@ -273,6 +273,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/spatial/1field_few_balanced/description.py
+++ b/examples/opf/experiments/anomaly/spatial/1field_few_balanced/description.py
@@ -273,6 +273,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/spatial/1field_few_skewed/description.py
+++ b/examples/opf/experiments/anomaly/spatial/1field_few_skewed/description.py
@@ -273,6 +273,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/spatial/2field_few_6040/description.py
+++ b/examples/opf/experiments/anomaly/spatial/2field_few_6040/description.py
@@ -274,6 +274,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/spatial/2field_few_balanced/description.py
+++ b/examples/opf/experiments/anomaly/spatial/2field_few_balanced/description.py
@@ -274,6 +274,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/spatial/2field_few_skewed/description.py
+++ b/examples/opf/experiments/anomaly/spatial/2field_few_skewed/description.py
@@ -274,6 +274,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/spatial/2field_many_balanced/description.py
+++ b/examples/opf/experiments/anomaly/spatial/2field_many_balanced/description.py
@@ -274,6 +274,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/spatial/2field_many_novelAtEnd/description.py
+++ b/examples/opf/experiments/anomaly/spatial/2field_many_novelAtEnd/description.py
@@ -274,6 +274,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/spatial/2fields_many_skewed/description.py
+++ b/examples/opf/experiments/anomaly/spatial/2fields_many_skewed/description.py
@@ -274,6 +274,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/spatial/novel_combination/description.py
+++ b/examples/opf/experiments/anomaly/spatial/novel_combination/description.py
@@ -274,6 +274,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/spatial/simple/description.py
+++ b/examples/opf/experiments/anomaly/spatial/simple/description.py
@@ -274,6 +274,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/temporal/hotgym/description.py
+++ b/examples/opf/experiments/anomaly/temporal/hotgym/description.py
@@ -296,6 +296,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/temporal/noisy_saw/description.py
+++ b/examples/opf/experiments/anomaly/temporal/noisy_saw/description.py
@@ -284,6 +284,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/temporal/saw_200/description.py
+++ b/examples/opf/experiments/anomaly/temporal/saw_200/description.py
@@ -284,6 +284,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/temporal/saw_200_category/description.py
+++ b/examples/opf/experiments/anomaly/temporal/saw_200_category/description.py
@@ -273,6 +273,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/temporal/saw_big/description.py
+++ b/examples/opf/experiments/anomaly/temporal/saw_big/description.py
@@ -284,6 +284,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/anomaly/temporal/simple/description.py
+++ b/examples/opf/experiments/anomaly/temporal/simple/description.py
@@ -287,6 +287,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/missing_record/base/description.py
+++ b/examples/opf/experiments/missing_record/base/description.py
@@ -303,6 +303,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/multistep/base/description.py
+++ b/examples/opf/experiments/multistep/base/description.py
@@ -289,6 +289,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/multistep/hotgym/description.py
+++ b/examples/opf/experiments/multistep/hotgym/description.py
@@ -294,6 +294,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym/description.py
+++ b/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym/description.py
@@ -277,6 +277,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym_1hr_agg/description.py
+++ b/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym_1hr_agg/description.py
@@ -298,6 +298,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym_no_agg/description.py
+++ b/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym_no_agg/description.py
@@ -298,6 +298,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;

--- a/examples/opf/experiments/spatial_classification/base/description.py
+++ b/examples/opf/experiments/spatial_classification/base/description.py
@@ -291,6 +291,9 @@ config = {
         },
 
         'clParams': {
+            # Classifier implementation selection.
+            'implementation': 'cpp',
+            
             'regionName' : 'CLAClassifierRegion',
 
             # Classifier diagnostic output verbosity control;


### PR DESCRIPTION
Some of the OPF examples were missing the classifier implementation
parameter in their parameter files, which prevented them from running. Fixes #734
