### PR TITLE
Update Dockerfile to Work with Recent CMake Build Process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir $REPOSITORY/build_system
 WORKDIR $REPOSITORY/build_system
 RUN cmake $REPOSITORY
 
-# Build
+# Build with max 3 jobs/threads
 RUN make -j3
 
 # Cleanup


### PR DESCRIPTION
Now builds without errors. 

I think many of the remaining environment variables can probably be removed now. 

Related issue: https://github.com/numenta/docker-nupic/issues/2
