### PR TITLE
Confirms $NTA != $NUPIC after applying defaults to them.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,13 +175,6 @@ endmacro()
 ############################################################################################################################
 
 #
-# Cannot have same $NTA and $NuPIC
-#
-if("$ENV{NTA}" STREQUAL "$ENV{NUPIC}")
-  message(FATAL_ERROR "\$NTA environment variable cannot be the same as the \$NUPIC environment variable!")
-endif()
-
-#
 # Set C++ compiler.
 # According to CMake documentation, this must be done before any language is set (ie before any project() or enable_language() command).
 #
@@ -454,6 +447,13 @@ if(OSX)
   message(STATUS "  (some variables will be updated only after login.)")
 endif()
 show_environment_variable(NTAX_DEVELOPER_BUILD "$ENV{NTAX_DEVELOPER_BUILD}")
+
+#
+# Cannot have same $NTA and $NuPIC
+#
+if("$ENV{NTA}" STREQUAL "$ENV{NUPIC}")
+  message(FATAL_ERROR "\$NTA environment variable cannot be the same as the \$NUPIC environment variable!")
+endif()
 
 #
 # Project details


### PR DESCRIPTION
Confirms $NTA != $NUPIC after applying defaults to them.

Reasoning:
1. This fixes #755
2. This prevents anything breaking $NTA != $NUPIC ( #659 ) in the process of setting these environment variables.
