### PR TITLE
Restore run_tests.sh

### DIFF
--- a/bin/run_tests.py
+++ b/bin/run_tests.py
@@ -75,7 +75,7 @@ def collect_list(option, opt_str, value, parser):
   setattr(parser.values, option.dest, value)
 
 
-parser = OptionParser(usage="%prog [options]\n\nRun Grok Engine tests.")
+parser = OptionParser(usage="%prog [options]\n\nRun NuPIC Python tests.")
 parser.add_option(
   "-a",
   "--all",
@@ -133,7 +133,7 @@ parser.add_option(
 def main(parser, parse_args):
   """ Parse CLI options and execute tests """
 
-  # Default to success, failures will flip it. 
+  # Default to success, failures will flip it.
   exitStatus = 0
 
   # Extensions to test spec (args not part of official test runner)
@@ -252,8 +252,8 @@ if __name__ == "__main__":
   # Tests need to run from $NUPIC, so let's change there and at the end back to actual_dir
   actual_dir=os.getcwd()
   os.chdir(os.getenv('NUPIC'))
-  
+
   result = main(parser, sys.argv[1:])
-  
+
   os.chdir(actual_dir)
   sys.exit(result)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-actual_dir = "$PWD"
-cd $NUPIC
-python bin/run_tests.py $@ || exit
-cd "$actual_dir"
+pushd $NUPIC > /dev/null
+python ./bin/run_tests.py $@ || exit
+popd > /dev/null


### PR DESCRIPTION
`run_tests.sh` was abruptly, and without discussion, removed from the nupic source tree, breaking internal grok pipelines, and developer workflow (see git hooks).  Lack of run_tests.sh also violates numenta standard test runner specification.  This PR restores it.
