### PR TITLE
Ignore "dirty" nupic.core submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "nupic.core"]
 	path = nta
 	url = git://github.com/numenta/nupic.core.git
+	ignore = dirty


### PR DESCRIPTION
`ignore = dirty` option avoids that git includes the word -dirty in the end of the submodule SHA when files in a submodule folder are changed.. If these changes aren't reverted, it's impossible synchronize nupic repo with a "dirty" submodule.. 

As we should pull PRs directly from `nupic.core` repo cloned to our machine, not from its `/nta` subfolder in `nupic`, I think is simpler ignore the changes were in `/nta` and so avoid typing commands to ignore manually these changes..

I saw several developers that recommend this option:

http://stackoverflow.com/questions/3240881/git-can-i-suppress-listing-of-modified-content-dirty-submodule-entries-in-sta

http://www.nils-haldenwang.de/frameworks-and-tools/git/how-to-ignore-changes-in-git-submodules

bronson/vim-update-bundles#32
