### PR TITLE
Add spatialImp option to multistep/hotgym experiment description file

### DIFF
--- a/examples/opf/experiments/multistep/hotgym/description.py
+++ b/examples/opf/experiments/multistep/hotgym/description.py
@@ -168,7 +168,7 @@ config = {
             # Spatial Pooler implementation selector, see getSPClass 
             # in py/regions/SPRegion.py for details
             # 'py', 'oldpy' (default), 'cpp' (speed optimized, new)
-            'spatialImp' : 'py', 
+            'spatialImp' : 'cpp', 
 
             'globalInhibition': 1,
 


### PR DESCRIPTION
The hotgym example from the README is missing the `spatialImp` option. This PR adds it.

@subutai 
