### PR TITLE
Dockerfile bugfix for Docker Trusted Builds

### DIFF
--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -48,8 +48,5 @@ RUN cmake $NUPIC
 # Build with max 3 jobs/threads
 RUN make -j3
 
-# Cleanup
-RUN rm /setuptools*
-
 # Default directory
 WORKDIR /home/docker


### PR DESCRIPTION
For some reason the recent ubuntu trusted builds are consistently failing on this line.  I don't think there's any harm in removing this line from the Dockerfile.

https://index.docker.io/u/numenta/nupic-ubuntu/builds_history/14933/
and https://index.docker.io/u/numenta/nupic/builds_history/15031/

cc: @allanino
