### PR TITLE
changes jobHash generator to base64 from uuid

### DIFF
--- a/py/nupic/database/ClientJobsDAO.py
+++ b/py/nupic/database/ClientJobsDAO.py
@@ -31,6 +31,9 @@ import sys
 import traceback
 import uuid
 
+from base64 import b64encode
+from os import urandom
+
 from nupic.support.decorators import logExceptions #, logEntryExit
 import pymysql
 from pymysql.constants import ER as mysqlerrors
@@ -1429,7 +1432,7 @@ class ClientJobsDAO(object):
     retval:          jobID - unique ID assigned to this job
     """
 
-    jobHash = self._normalizeHash(uuid.uuid1().bytes)
+    jobHash = self._normalizeHash(b64encode(urandom(10)))
 
     @g_retrySQL
     def insertWithRetries():


### PR DESCRIPTION
jobHash was generated with uuid, but it gives PySQL utf-8 issue

so that jobHash generator changed to base64

Fixes #883
