### PR TITLE
Simple fix for NTA_ASM define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -618,6 +618,7 @@ if(NTA_OPTIMIZATION_ENABLED)
   # flag NTA_ASM enables/disables our hand tuned assbembly code (SSE), but it's available only for some platform
   set(NTA_CXXFLAGS_OPTIMIZATION "-O3 -pipe -DNTA_ASM")
   set(NTA_CXXFLAGS_OPTIMIZATION_PYMODULE "-O1")
+  set(NTA_CXXFLAGS_BASE "${NTA_CXXFLAGS_BASE} -DNTA_ASM")
 else()
   set(NTA_CXXFLAGS_OPTIMIZATION "-O0 -fno-inline")
   set(NTA_CXXFLAGS_OPTIMIZATION_PYMODULE "-O0 -fno-inline")


### PR DESCRIPTION
NTA_ASM needs to be added to the CXX flags so that it is picked up
when swig wrappers are compiled.

Fixes #923.
