### PR TITLE
Adding OSX to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,29 +12,6 @@ compiler:
   - clang
   - gcc
 
-# matrix:
-  # include:
-    # # Testing on linux for Python 2.6 & 2.7, clang & gcc
-    # - os: linux
-    #   compiler: clang
-    #   env:
-    #     - PY_VER=2.6
-    # - os: linux
-    #   compiler: gcc
-    #   env:
-    #     - PY_VER=2.6
-    # - os: linux
-    #   compiler: clang
-    #   env:
-    #     - PY_VER=2.7
-    # - os: linux
-    #   compiler: gcc
-    #   env:
-    #     - PY_VER=2.7
-    # # For OSX, just testing clang and default Python (2.7)
-    # - os: osx
-    #   compiler: clang
-
 env:
   global:
     - NUPIC=$TRAVIS_BUILD_DIR
@@ -45,6 +22,7 @@ env:
     - PY_VER=2.6
 
 matrix:
+  # This excludes OSX builds from the build matrix for gcc and Python 2.6
   exclude:
     - os: osx
       env: PY_VER=2.6


### PR DESCRIPTION
Only supports Python 2.7 (default version on OSX) and clang, which is the most typical use-case anyway. Getting gcc installed on the latest OSX is a pain, same with Python 2.6.

Had to manually define the build matrix to do this. Also make many prerequisite commands conditional on the OS. 

Fixes #932.
