### PR TITLE
Swarm error messages

### DIFF
--- a/py/nupic/encoders/base.py
+++ b/py/nupic/encoders/base.py
@@ -211,8 +211,10 @@ class Encoder(object):
     """
     if isinstance(obj, dict):
       if not fieldName in obj:
-        knownFields = ",".join([key for key in obj.keys() if key[:1] != "_"])
-        raise Exception(
+        knownFields = ", ".join(
+          key for key in obj.keys() if not key.startswith("_")
+        )
+        raise ValueError(
           "Unknown field name '%s' in input record. Known fields are '%s'.\n"
           "This could be because input headers are mislabeled, or because "
           "input data rows do not contain a value for '%s'." % (

--- a/py/nupic/frameworks/opf/clamodel.py
+++ b/py/nupic/frameworks/opf/clamodel.py
@@ -724,9 +724,13 @@ class CLAModel(Model):
 
 
     # Get the actual value and the bucket index for this sample. The
-    #  predicted field may not be enabled for input to the network, so we
-    #  explicitly encode it outside of the sensor
+    # predicted field may not be enabled for input to the network, so we
+    # explicitly encode it outside of the sensor
     # TODO: All this logic could be simpler if in the encoder itself
+    if not predictedFieldName in rawInput:
+      raise ValueError("Input row does not contain a value for the predicted "
+                       "field configured for this model. Missing value for '%s'"
+                       % predictedFieldName)
     absoluteValue = rawInput[predictedFieldName]
     bucketIdx = self._classifierInputEncoder.getBucketIndices(absoluteValue)[0]
 

--- a/py/nupic/frameworks/opf/exp_generator/ExpGenerator.py
+++ b/py/nupic/frameworks/opf/exp_generator/ExpGenerator.py
@@ -1911,7 +1911,7 @@ def _getPredictedField(options):
       break
 
   if predictedFieldInfo is None:
-    raise Exception(
+    raise ValueError(
       "Predicted field '%s' does not exist in included fields." % predictedField
     )
   predictedFieldType = predictedFieldInfo['fieldType']

--- a/py/nupic/swarming/permutations_runner.py
+++ b/py/nupic/swarming/permutations_runner.py
@@ -809,7 +809,7 @@ class _HyperSearchRunner(object):
 
     # Try to return a decent error message if the job was cancelled for some
     # reason.
-    if jobInfo.cancel is 1:
+    if jobInfo.cancel == 1:
       raise Exception(jobInfo.workerCompletionMsg)
 
     try:


### PR DESCRIPTION
Fixes #888.

Decent errors are now returned for the following tested cases:
- swarm description contains a predicted field that does not exist in include fields
- input csv data contains header(s) that do not exist in swarm description
- input csv data contains rows with missing data fields (null fields are ok)

This PR includes a change to the base encoder, so @scottpurdy or @chetan51 please review.
