### PR TITLE
Fix Dockerfile link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+.docker/ubuntu/Dockerfile


### PR DESCRIPTION
This mutually exclusive of numenta/nupic#1032.

Docker builds are broken due to a bad `Dockerfile` link.

Comparing the current master on top of the previous commit to Dockerfile:

```
austins-mbp-3:nupic amarshall$ git diff 46e89a9..26c9402 -- Dockerfile
diff --git a/Dockerfile b/Dockerfile
index a458504..d8934fc 120000
--- a/Dockerfile
+++ b/Dockerfile
@@ -1 +1 @@
-docker/ubuntu/Dockerfile
\ No newline at end of file
+.docker/ubuntu/Dockerfile
```

Notice the "No newline at end of file" in the first file, and compare to the fix proposed here:

```
austins-mbp-3:nupic amarshall$ git diff 46e89a9..214d271 -- Dockerfile
diff --git a/Dockerfile b/Dockerfile
index a458504..d437f61 120000
--- a/Dockerfile
+++ b/Dockerfile
@@ -1 +1 @@
-docker/ubuntu/Dockerfile
\ No newline at end of file
+.docker/ubuntu/Dockerfile
\ No newline at end of file
```

Which is the difference between:

```
$ ls -l Dockerfile 
lrwxr-xr-x  1 amarshall  staff  26 Jun 21 22:17 Dockerfile -> .docker/ubuntu/Dockerfile?
```

In which the Dockerfile, at the root of the project is inaccessible:

```
$ cat Dockerfile 
cat: Dockerfile: No such file or directory
```

And:

```
$ ls -l Dockerfile 
lrwxr-xr-x  1 amarshall  staff  25 Jun 21 22:22 Dockerfile -> .docker/ubuntu/Dockerfile
```

In which Dockerfile is accessible and can be read.

As a reminder: Docker requires a single `Dockerfile` at the root, and in our case a symlink is used in order to avoid duplication in maintaining multiple flavors (Ubuntu vs CentOS) of Dockerfile, hence `docker/*/Dockerfile`
