### PR TITLE
added clamodel to doxs

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -755,6 +755,9 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = docs \
+                         py/nupic/frameworks/opf/__init__.py \
+                         py/nupic/frameworks/opf/clamodel.py \
+                         py/nupic/frameworks/opf/modelfactory.py \
                          nupic/research/__init__.py \
                          nupic/research/TP10X2.py \
                          nupic/research/TPTrivial.py \

--- a/nupic/frameworks/opf/clamodel.py
+++ b/nupic/frameworks/opf/clamodel.py
@@ -19,7 +19,11 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-"""Encapsulation of CLAnetwork that implements the ModelBase."""
+""" @file clamodel.py
+
+Encapsulation of CLAnetwork that implements the ModelBase.
+
+"""
 
 import copy
 import math
@@ -638,8 +642,22 @@ class CLAModel(Model):
 
       # Calculate the anomaly score using the active columns
       # and previous predicted columns
+<<<<<<< HEAD:nupic/frameworks/opf/clamodel.py
       inferences[InferenceElement.anomalyScore] = (
           computeAnomalyScore(activeColumns, self._prevPredictedColumns))
+=======
+
+      # Test whether each element of a 1-D array is also present in a second
+      # array. Sum to get the total # of columns that are active and were
+      # predicted.
+      score = numpy.in1d(activeColumns, self._prevPredictedColumns).sum()
+
+      # Get the percent of active columns that were NOT predicted, that is
+      # our anomaly score.
+      score = (nActiveColumns - score) / float(nActiveColumns)
+
+      inferences[InferenceElement.anomalyScore] = score
+>>>>>>> 45e5d7bc20af7766de1199dace43e49c28420877:py/nupic/frameworks/opf/clamodel.py
 
       # Store the predicted columns for the next timestep
       predictedColumns = tp.getOutputData("topDownOut").nonzero()[0]

--- a/nupic/frameworks/opf/modelfactory.py
+++ b/nupic/frameworks/opf/modelfactory.py
@@ -19,6 +19,11 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
+""" @file modelfactory.py
+
+ Model factory.
+"""
+
 import os
 import logging
 
@@ -72,7 +77,7 @@ class ModelFactory(object):
     else:
       raise Exception("ModelFactory received unsupported Model type: %s" % \
                       modelConfig['model'])
-    
+
     return modelClass(**modelConfig['modelParams'])
 
   @staticmethod


### PR DESCRIPTION
To fix https://github.com/numenta/nupic/issues/497
and https://github.com/numenta/nupic/issues/1093

Adds frameworks/opf/clamodel.py  and frameworks/opf/modelfactory.py  to doxygen docs.
