### PR TITLE
Uses 'develop' option if no option is passed to 'setup.py'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,12 +74,12 @@ def build_extensions_nupic():
   # Generate build files with CMake
   return_code = subprocess.call('cmake ' + sourceDir + ' ' + cmakeOptions, shell=True)
   if (return_code != 0):
-    sys.exit('Unable to generate build scripts!')
+    sys.exit("Unable to generate build scripts!")
 
   # Build library with Make
   return_code = subprocess.call('make ' + makeOptions, shell=True)
   if (return_code != 0):
-    sys.exit('Unable to build the library!')
+    sys.exit("Unable to build the library!")
 
 
 def setup_nupic():
@@ -101,7 +101,7 @@ def setup_nupic():
       'nupic.frameworks.opf.jsonschema': ['*.json'],
       'nupic.support.resources.images': ['*.png', '*.gif', '*.ico', '*.graffle'],
       'nupic.swarming.jsonschema': ['*.json']},
-    description = 'Numenta Platform for Intelligent Computing',
+    description = "Numenta Platform for Intelligent Computing",
     author='Numenta',
     author_email='help@numenta.org',
     url='https://github.com/numenta/nupic',


### PR DESCRIPTION
Now `setup.py` checks if no option was passed, i.e. if `setup.py` is the only option. If it's the case, `build` is passed by default. This is very useful when a developer wish build the project directly from an IDE*.

This should work well both with IDE and shell interface. After merged we can replace the current CMake instructions (https://github.com/numenta/nupic/wiki/Development-Tips) to these simplified ones:

```
These following instructions will work in the most Python IDEs:
1. Open your IDE.
2. Open a project specifing the $NUPIC repository folder as location. 
3. Click with mouse right button on `setup.py` file listed on project files and select `Run` command on popup menu. This will call the build process. Check `output` panel to see the result.
4. If the build was sucessful, just click in any file with `run_*` preffix in `/scripts` folder and voilá!
```

In addition to we have simplified instructions, we get rid of a limited number of IDEs supported by CMake with focus only on C++ whereas in reality Nupic is a python project with a few c++ extensions.
