### PR TITLE
Top down compute fix

### DIFF
--- a/nupic/frameworks/opf/clamodel.py
+++ b/nupic/frameworks/opf/clamodel.py
@@ -479,7 +479,7 @@ class CLAModel(Model):
     if tp is None:
       return
 
-    if (inferenceType == InferenceType.TemporalAnomaly or
+    if (self.getInferenceType() == InferenceType.TemporalAnomaly or
         self._isReconstructionModel()):
       topDownCompute = True
     else:

--- a/nupic/regions/TPRegion.py
+++ b/nupic/regions/TPRegion.py
@@ -501,7 +501,7 @@ class TPRegion(PyRegion):
     # Write the bottom up out to our node outputs
     outputs['bottomUpOut'][:] = tpOutput.flat
 
-    if self.topdownMode:
+    if self.topDownMode:
       # Top-down compute
       outputs['topDownOut'][:] = self._tfdr.topDownCompute().copy()
 


### PR DESCRIPTION
Fixes #1183.

This PR resolves this by passing topDownCompute appropriately when calling TPRegion.compute and changes the region to correctly always call the TP compute method and optionally additionally compute the top down output.
