### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For all installation options, see the [Installing and Building NuPIC](https://gi
 
 Currently supported platforms:
  * Linux (32/64bit)
- * Mac OSX
+ * Mac OS X
  * Raspberry Pi (ARMv6)
  * Chromebook (Ubuntu ARM, Crouton) (ARMv7)
  * [VM images](https://github.com/numenta/nupic/wiki/Running-Nupic-in-a-Virtual-Machine)


### PR DESCRIPTION
There should be a space between OS and X. This has only been proposed since that is the official name the distributor has provided. It should now read "OS X".
