### PR TITLE
SP permanence initialization test

### DIFF
--- a/tests/unit/py2/nupic/research/spatial_pooler_compatability_test.py
+++ b/tests/unit/py2/nupic/research/spatial_pooler_compatability_test.py
@@ -412,7 +412,7 @@ class SpatialPoolerCompatabilityTest(unittest.TestCase):
     def max_perm(sp):
       numCols = sp.getNumColumns()
       numInputs = sp.getNumInputs()
-      perm = numpy.zeros(numInputs)
+      perm = numpy.zeros(numInputs).astype(realType)
       max_perm = 0
       for col in range(numCols):
         sp.getPermanence(col, perm)


### PR DESCRIPTION
Added a compatibility test to check for equivalent permanence initialization between the Python and C++ spatial poolers as suggested by @breznak.

Work towards numenta/nupic.core#159. 
Fixes #1225.

See #1223 for history.
