### PR TITLE
SunOS/Solaris support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,7 +291,7 @@ macro(generate_submodule_library name submodule_dir extra_cxxflags extra_linkfla
   execute_process(COMMAND ${CMAKE_COMMAND} ${submodule_dir}/src -DUSER_CXXFLAGS:STRING=${extra_cxxflags} -DUSER_LINKFLAGS:STRING=${extra_linkflags}
                   WORKING_DIRECTORY ${submodule_dir}/build/scripts)
   # Execute the Make scripts
-  execute_process(COMMAND make -j3
+  execute_process(COMMAND ${USER_MAKE_COMMAND} -j3
                   WORKING_DIRECTORY ${submodule_dir}/build/scripts
                   RESULT_VARIABLE EXIT_CODE)
   if(NOT EXIT_CODE EQUAL 0)
@@ -356,6 +356,8 @@ if(NOT "${USER_CXX_COMPILER}" STREQUAL "")
   set(CMAKE_CXX_COMPILER "${USER_CXX_COMPILER}")
 endif()
 
+set(USER_MAKE_COMMAND "make" CACHE STRING "Default `make` command used to build nupic.core")
+
 #
 # Sets default locations.
 #
@@ -403,6 +405,9 @@ if(UNIX)
   elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(LINUX ON)
     set(DYNAMIC_LIB_EXTENSION "so")
+  elseif(${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
+    set(SOLARIS ON)
+    set(DYNAMIC_LIB_EXTENSION "so")
   endif()
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   set(WINDOWS ON)
@@ -424,6 +429,8 @@ endif()
 set(NTA_PLATFORM_CXXFLAGS "-fPIC -DPIC")
 set(NTA_PLATFORM_LINKFLAGS "")
 set(NTA_PLATFORM_LIBS "-std=c++98")
+set(NUPIC_CORE_EXTRA_CXXFLAGS "")
+set(NUPIC_CORE_EXTRA_LINKFLAGS "")
 if(OSX)
   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.7")
   set(NTA_PLATFORM_OS "darwin64")
@@ -449,6 +456,17 @@ elseif(LINUX)
 elseif(WINDOWS)
   set(NTA_PLATFORM_OS "win32")
   set(NTA_PLATFORM_CXXFLAGS "${NTA_PLATFORM_CXXFLAGS} -DWIN32")
+elseif(SOLARIS)
+  set(NTA_PLATFORM_DEBUGFLAGS "-g")
+  set(NTA_PLATFORM_LINKFLAGS "${NTA_PLATFORM_LINKFLAGS} -m64 -static-libgcc -Wl,-ztext,-zignore,-zallextract")
+  set(NTA_PLATFORM_LIBS "${NTA_PLATFORM_LIBS} -L${PROJECT_BUILD_RELEASE_DIR}/lib -L ${REPOSITORY_DIR}/lib/external/sparc64/lib -lm -lpthread -ldl -laprutil-1 -lapr-1 -lyaml-cpp -lyaml -Wl,-zdefaultextract")
+  execute_process(COMMAND isainfo -b OUTPUT_VARIABLE NTA_PLATFORM_ARCH)
+  set(NTA_PLATFORM_OS "sparc64")
+  set(NUPIC_CORE_EXTRA_CXXFLAGS, "${NUPIC_CORE_EXTRA_CXXFLAGS} -fPIC -m64")
+  set(NUPIC_CORE_EXTRA_LINKFLAGS, "${NUPIC_CORE_EXTRA_LINKFLAGS} -m64")
+  set(NTA_PLATFORM_CXXFLAGS "${NTA_PLATFORM_CXXFLAGS} -m64")
+  set(NTA_PLATFORM_CXXFLAGS_PYEMBED "-m64")
+  set(NTA_PLATFORM_LINKFLAGS_PYMODULE "-pthread -m64 -Wl,-ztext,-zignore,-zallextract")
 else()
   message(FATAL_ERROR "${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}: error: ${CMAKE_SYSTEM_NAME} not supported yet.")
 endif()
@@ -496,6 +514,8 @@ execute_process(COMMAND ${PYTHON} -c "import sys;sys.stdout.write(str(sys.versio
 if(NOT(${PYTHON_VERSION} EQUAL "2.6" OR ${PYTHON_VERSION} EQUAL "2.7"))
   message(FATAL_ERROR "Only these versions of Python are accepted: 2.6, 2.7")
 endif()
+
+set(NUPIC_CORE_EXTRA_CXXFLAGS, "-DNTA_PYTHON_SUPPORT=${PYTHON_VERSION} ${NUPIC_CORE_EXTRA_CXXFLAGS}")
 
 #
 # Find out where system installation of python is.
@@ -588,7 +608,7 @@ add_definitions(-std=c++98) # smart flag setting for gcc/clang
 # Allows us to find includes for external libraries and enables
 # #include <nta/common/...>
 #
-set(NTA_INCLUDEFLAGS "-I${REPOSITORY_DIR} -I${REPOSITORY_DIR}/extensions -I${PROJECT_BUILD_INCLUDE_DIR} -isystem${REPOSITORY_DIR}/extensions/core/external/common/include -isystem${REPOSITORY_DIR}/extensions/core/external/${NTA_PLATFORM_OS}/include -isystem${REPOSITORY_DIR}/external/common/include -isystem${REPOSITORY_DIR}/external/${NTA_PLATFORM_OS}/include")
+set(NTA_INCLUDEFLAGS "-I${REPOSITORY_DIR} -I${REPOSITORY_DIR}/include -I${PROJECT_BUILD_INCLUDE_DIR}  -I${REPOSITORY_DIR}/extensions -I${PROJECT_BUILD_RELEASE_DIR}/include -isystem${REPOSITORY_DIR}/extensions/core/external/${NTA_PLATFORM_OS}/include -isystem${REPOSITORY_DIR}/extensions/core/external/common/include -isystem${REPOSITORY_DIR}/external/${NTA_PLATFORM_OS}/include -isystem${REPOSITORY_DIR}/external/common/include")
 
 #
 # NTA_INTERNAL tells us that the code is being built under the build system
@@ -748,7 +768,7 @@ endif()
 read_variable_from_file("${MODULES_FILE_CONTENT}" "NUPIC_CORE_REMOTE" NUPIC_CORE_REMOTE)
 read_variable_from_file("${MODULES_FILE_CONTENT}" "NUPIC_CORE_COMMITISH" NUPIC_CORE_COMMITISH)
 set(LIB_STATIC_NUPICCORE nupic_core)
-generate_submodule_library(${LIB_STATIC_NUPICCORE} "${REPOSITORY_DIR}/extensions/core" "-DNTA_PYTHON_SUPPORT=${PYTHON_VERSION}" "" "${NUPIC_CORE_REMOTE}" "${NUPIC_CORE_COMMITISH}")
+generate_submodule_library(${LIB_STATIC_NUPICCORE} "${REPOSITORY_DIR}/extensions/core" "${NUPIC_CORE_EXTRA_CXXFLAGS}" "${NUPIC_CORE_EXTRA_LINKFLAGS}" "${NUPIC_CORE_REMOTE}" "${NUPIC_CORE_COMMITISH}")
 
 #
 # HtmTest

--- a/extensions/py_support/NumpyVector.cpp
+++ b/extensions/py_support/NumpyVector.cpp
@@ -69,7 +69,7 @@ NTA_DEF_NUMPY_DTYPE_TRAIT(nta::Byte, PyArray_BYTE);
 NTA_DEF_NUMPY_DTYPE_TRAIT(nta::Int16, PyArray_INT16);
 NTA_DEF_NUMPY_DTYPE_TRAIT(nta::UInt16, PyArray_UINT16);
 
-#if defined(NTA_PLATFORM_linux64) || defined(NTA_PLATFORM_darwin64)
+#if defined(NTA_PLATFORM_linux64) || defined(NTA_PLATFORM_sparc64) || defined(NTA_PLATFORM_darwin64)
 NTA_DEF_NUMPY_DTYPE_TRAIT(size_t, PyArray_UINT64);
 #else
 NTA_DEF_NUMPY_DTYPE_TRAIT(size_t, PyArray_UINT32);
@@ -84,7 +84,7 @@ NTA_DEF_NUMPY_DTYPE_TRAIT(nta::UInt32, PyArray_UINT32);
 
 NTA_DEF_NUMPY_DTYPE_TRAIT(nta::Int64, PyArray_INT64);
 
-#if !defined(NTA_PLATFORM_linux64) && !defined(NTA_PLATFORM_darwin64)
+#if !defined(NTA_PLATFORM_linux64) && !defined(NTA_PLATFORM_sparc64) && !defined(NTA_PLATFORM_darwin64)
 NTA_DEF_NUMPY_DTYPE_TRAIT(nta::UInt64, PyArray_UINT64);
 #endif
 

--- a/external/sparc64/README.md
+++ b/external/sparc64/README.md
@@ -1,0 +1,18 @@
+NuPIC external libraries
+=============================
+
+NuPIC depends on Swig, for creating python language bindings.  Swig is
+normally distributed with the source, however, since Solaris is not an
+officially supported platform, you will need to build the libraries yourself.
+Use the following commands as a guide.
+
+**BEFORE YOU BEGIN:** Obtain the source for Swig 1.3.36 and extract in
+$NUPIC/external/sparc64
+
+```
+cd $NUPIC/external/sparc64/swig-1.3.36
+gmake clean
+CFLAGS="-m64 -fPIC" CXXFLAGS="-m64 -fPIC" LDFLAGS="-m64" ./configure --prefix=$NUPIC/external/sparc64
+VERBOSE=1 gmake
+gmake install
+```


### PR DESCRIPTION
re: numenta/nupic#918

This also adds the option for specifying the `make` command used to build nupic.core, for example to use gmake:

`cmake -DUSER_MAKE_COMMAND=gmake ...`

Aside from reordering some compiler arguments, this doesn't affect non-solaris builds.
