### PR TITLE
Revert "Updates nupic.core to c5e8e3a7d03b6edaa20276cda5fa1c13c7836711."

### DIFF
--- a/.nupic_modules
+++ b/.nupic_modules
@@ -1,3 +1,3 @@
 # Default nupic.core dependencies (override in optional .nupic_config)
 NUPIC_CORE_REMOTE = 'git://github.com/numenta/nupic.core.git'
-NUPIC_CORE_COMMITISH = 'c5e8e3a7d03b6edaa20276cda5fa1c13c7836711'
+NUPIC_CORE_COMMITISH = 'c3dc7b8affa8162a85dc8c77cd6dadee84d79e90'


### PR DESCRIPTION
This reverts commit ae7ac7f089f6379496dc43b3c52d9ccefdb9a8c0.

@rhyolight - you merged this recently but it results in mismatch in nupic/nupic.core. I have an outstanding PR to fix that (#1189) but I can't debug it due to build problems. My proposal is that we revent the SHA upgrade now and I will work with @oxtopus to get the build situation resolved and subsequently get #1189 merged.
