### PR TITLE
Returning failure exit code for test scripts.

### DIFF
--- a/ci/travis/script-run-examples.sh
+++ b/ci/travis/script-run-examples.sh
@@ -24,33 +24,21 @@ echo
 echo Running `basename $0`...
 echo
 
-check_previous_exit_status () { if [ $? -ne 0 ]; then exit $?; fi; }
-
-python$PY_VER $NUPIC/examples/bindings/sparse_matrix_how_to.py
-check_previous_exit_status
-# python $NUPIC/examples/bindings/svm_how_to.py # tkinter missing in Travis build machine
-# python $NUPIC/examples/bindings/temporal_pooler_how_to.py # tkinter too
+python$PY_VER $NUPIC/examples/bindings/sparse_matrix_how_to.py || exit
+# python $NUPIC/examples/bindings/svm_how_to.py || exit # tkinter missing in Travis build machine
+# python $NUPIC/examples/bindings/temporal_pooler_how_to.py || exit # tkinter too
 
 # examples/opf (run at least 1 from each category)
-python$PY_VER $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/anomaly/spatial/2field_few_skewed/
-check_previous_exit_status
-python$PY_VER $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/anomaly/temporal/saw_200/
-check_previous_exit_status
-python$PY_VER $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/classification/category_TP_1/
-check_previous_exit_status
-python$PY_VER $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/missing_record/simple_0/
-check_previous_exit_status
-python$PY_VER $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/multistep/hotgym/
-check_previous_exit_status
-python$PY_VER $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym_1hr_agg/
-check_previous_exit_status
+python$PY_VER $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/anomaly/spatial/2field_few_skewed/ || exit
+python$PY_VER $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/anomaly/temporal/saw_200/ || exit
+python$PY_VER $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/classification/category_TP_1/ || exit
+python$PY_VER $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/missing_record/simple_0/ || exit
+python$PY_VER $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/multistep/hotgym/ || exit
+python$PY_VER $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym_1hr_agg/ || exit
 
 # opf/experiments/params - skip now
-python$PY_VER $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/spatial_classification/category_1/
-check_previous_exit_status
+python$PY_VER $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/spatial_classification/category_1/ || exit
 
 # examples/tp
-python$PY_VER $NUPIC/examples/tp/hello_tp.py
-check_previous_exit_status
-python$PY_VER $NUPIC/examples/tp/tp_test.py
-check_previous_exit_status
+python$PY_VER $NUPIC/examples/tp/hello_tp.py || exit
+python$PY_VER $NUPIC/examples/tp/tp_test.py || exit

--- a/ci/travis/script-run-tests.sh
+++ b/ci/travis/script-run-tests.sh
@@ -24,20 +24,15 @@ echo
 echo Running `basename $0`...
 echo
 
-check_previous_exit_status () { if [ $? -ne 0 ]; then exit $?; fi; }
-
 cd $TRAVIS_BUILD_DIR/build/scripts
 # legacy binary tests
-make tests_pyhtm
-check_previous_exit_status
+make tests_pyhtm || exit
 
 # Python unit tests and prep for coveralls reporting
-make python_unit_tests
-check_previous_exit_status
+make python_unit_tests || exit
 
 mv ${TRAVIS_BUILD_DIR}/.coverage ${TRAVIS_BUILD_DIR}/.coverage_unit
 # Python integration tests and prep for coveralls reporting
-make python_integration_tests
-check_previous_exit_status
+make python_integration_tests || exit
 
 mv ${TRAVIS_BUILD_DIR}/.coverage ${TRAVIS_BUILD_DIR}/.coverage_integration


### PR DESCRIPTION
Tests run within scripts were failing silently. I added bash logic after test
runs to check previous exit status and exit the script with a failure code if
the test commands failed.

Fixes #1293
