### PR TITLE
Fix broken Docker build

### DIFF
--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,9 +1,8 @@
-FROM ubuntu
+FROM ubuntu:14.04
 
 MAINTAINER Allan Costa <allaninocencio@yahoo.com.br>
 
 # Install dependencies
-RUN echo "deb http://archive.ubuntu.com/ubuntu trusty main universe" > /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get install -y wget
 RUN apt-get install -y git-core


### PR DESCRIPTION
See #1312.

It seems like this new Dockerfile is building correctly. As evidence, we can see a new Docker hub trusted build I created for this branch: [https://registry.hub.docker.com/u/allanino/new-nupic/builds_history/55181/](https://registry.hub.docker.com/u/allanino/new-nupic/builds_history/55181/).
