### PR TITLE
Fix column setup for inhibitColumn

### DIFF
--- a/tests/unit/py2/nupic/research/spatial_pooler_unit_test.py
+++ b/tests/unit/py2/nupic/research/spatial_pooler_unit_test.py
@@ -429,7 +429,7 @@ class SpatialPoolerTest(unittest.TestCase):
     # Test translation of numColumnsPerInhArea into local area density
     sp._numColumns = 1000
     sp._tieBreaker = numpy.zeros(1000)
-    sp._columnDimensions = numpy.array([10, 10])
+    sp._columnDimensions = numpy.array([100, 10])
     sp._inhibitColumnsGlobal.reset_mock()
     sp._inhibitColumnsLocal.reset_mock()
     sp._numActiveColumnsPerInhArea = 3
@@ -449,7 +449,7 @@ class SpatialPoolerTest(unittest.TestCase):
     # Test clipping of local area density to 0.5
     sp._numColumns = 1000
     sp._tieBreaker = numpy.zeros(1000)
-    sp._columnDimensions = numpy.array([10, 10])
+    sp._columnDimensions = numpy.array([100, 10])
     sp._inhibitColumnsGlobal.reset_mock()
     sp._inhibitColumnsLocal.reset_mock()
     sp._numActiveColumnsPerInhArea = 7


### PR DESCRIPTION
Fixes #1402 
Tests inconsistent with test parameters. Tests setup numColumns of 500 and 1000
but the column dimensions didn't match in two locations which could be confusing
to onlookers and is inconsistent.
