### PR TITLE
Optimize temporal memory

### DIFF
--- a/nupic/research/temporal_memory.py
+++ b/nupic/research/temporal_memory.py
@@ -371,7 +371,7 @@ class TemporalMemory(object):
     predictiveCells = set()
 
     for cell in activeCells:
-      for synapse, synapseData in connections.synapsesForSourceCell(cell):
+      for synapseData in connections.synapsesForSourceCell(cell).values():
         segment, _, permanence = synapseData
 
         numActiveSynapsesForSegment[segment] += 1
@@ -601,7 +601,7 @@ class Connections(object):
     # Indexes into the mappings (for performance)
     self._segmentsForCell = dict()
     self._synapsesForSegment = dict()
-    self._synapsesForSourceCell = defaultdict(set)
+    self._synapsesForSourceCell = defaultdict(dict)
 
     # Index of the next segment to be created
     self._nextSegmentIdx = 0
@@ -755,7 +755,7 @@ class Connections(object):
       self._synapsesForSegment[segment] = set()
     self._synapsesForSegment[segment].add(synapse)
 
-    self._synapsesForSourceCell[sourceCell].add((synapse, synapseData))
+    self._synapsesForSourceCell[sourceCell][synapse] = synapseData
 
     return synapse
 
@@ -775,8 +775,7 @@ class Connections(object):
 
     # Update indexes
     sourceCell = data[1]
-    self._synapsesForSourceCell[sourceCell].remove((synapse, data))
-    self._synapsesForSourceCell[sourceCell].add((synapse, newData))
+    self._synapsesForSourceCell[sourceCell][synapse] = newData
 
 
   # ==============================

--- a/tests/unit/py2/nupic/research/temporal_memory_test.py
+++ b/tests/unit/py2/nupic/research/temporal_memory_test.py
@@ -630,9 +630,9 @@ class ConnectionsTest(unittest.TestCase):
 
     self.assertEqual(connections.synapsesForSegment(0), set([0, 1]))
 
-    self.assertEqual(connections.synapsesForSourceCell(174), set())
+    self.assertEqual(connections.synapsesForSourceCell(174), {})
     self.assertEqual(connections.synapsesForSourceCell(254),
-                     set([(0, (0, 254, 0.1173))]))
+                     {0: (0, 254, 0.1173)})
 
 
   def testCreateSynapseInvalidParams(self):


### PR DESCRIPTION
Fixes https://github.com/numenta/nupic/issues/1410.
Fixes #1405.

Main optimization: Instead of storing the full set of active synapses for each segment, only store the number of active synapses for each segment, and separately store the indices of the active synapses for only the active segments (ones that caused a prediction).
