### PR TITLE
Correct cpp unit test name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -936,7 +936,7 @@ add_custom_target(tests_cpphtm
                   COMMENT "Basic tests in C++")
 
 add_custom_target(cpp_unit_tests
-                  COMMAND ${PROJECT_BUILD_BINARIES_DIR}/testeverything
+                  COMMAND ${PROJECT_BUILD_BINARIES_DIR}/unit_tests
                   COMMENT "C++ unit tests")
 
 # Tests_all just calls other targets


### PR DESCRIPTION
Fixes https://github.com/numenta/nupic/pull/1299#issuecomment-58131887 , replaces and closes #1299 :

>  there was one piese missing in #1409, the `cpp_unit_tests` is still referring to `testeverything` instead of the new name `unit_tests`.
