### PR TITLE
add logging to output errors to stdout

### DIFF
--- a/examples/opf/clients/hotgym/prediction/one_gym/swarm.py
+++ b/examples/opf/clients/hotgym/prediction/one_gym/swarm.py
@@ -26,6 +26,10 @@ Groups together the code dealing with swarming.
 import os
 import pprint
 
+# add logging to output errors to stdout
+import logging
+logging.basicConfig()
+
 from nupic.swarming import permutations_runner
 from swarm_description import SWARM_DESCRIPTION
 


### PR DESCRIPTION
This allows output to be presented to the end user when some error is logged.  Rather than getting a `no logging handler defined`, it will output the error to stdout.

This is especially helpful for people just getting started with NuPIC, for example the issue I just ran into was it would hang at the no logging handler defined, with no indication of whether or not it was going to continue, was in the middle of some process or what.

With the logging enabled, it immediately returned that access was denied to MySQL because I had a password set on my root account, but it was expecting no password.

These two lines might want to be added elsewhere in the project as well, but since this is probably where most people start, it should at least tell the end user what is wrong, rather than hang, outputting nothing.
