### PR TITLE
BUGFIX: Removed extraneous "I" in path to gtest, and duplicated call to generate_static_library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -797,6 +797,9 @@ if("${NUPIC_CORE}" STREQUAL "")
   read_variable_from_file("${MODULES_FILE_CONTENT}" "NUPIC_CORE_COMMITISH" NUPIC_CORE_COMMITISH)
   generate_submodule_library(${LIB_STATIC_NUPICCORE} "${REPOSITORY_DIR}/extensions/core" "${NUPIC_CORE_EXTRA_CXXFLAGS}" "${NUPIC_CORE_EXTRA_LINKFLAGS}" "${NUPIC_CORE_REMOTE}" "${NUPIC_CORE_COMMITISH}")
 
+  #
+  # Compile google test from source for linking with tests
+  #
   generate_static_library(${LIB_STATIC_GTEST} "${REPOSITORY_DIR}/extensions/core/external/common/src/gtest" "${PROJECT_BUILD_TEMP_DIR}/lib" "${NTA_CXXFLAGS}")
 
 else()
@@ -811,14 +814,11 @@ else()
   add_library(${LIB_STATIC_NUPICCORE} STATIC IMPORTED GLOBAL)
   set_property(TARGET ${LIB_STATIC_NUPICCORE} PROPERTY IMPORTED_LOCATION "${PROJECT_BUILD_LIBRARIES_DIR}/lib${LIB_STATIC_NUPICCORE}.${STATIC_LIB_EXTENSION}")
 
-  generate_static_library(${LIB_STATIC_GTEST} "I${NUPIC_CORE_SOURCE}/external/common/src/gtest" "${PROJECT_BUILD_TEMP_DIR}/lib" "${NTA_CXXFLAGS}")
+  #
+  # Compile google test from source for linking with tests
+  #
+  generate_static_library(${LIB_STATIC_GTEST} "${NUPIC_CORE_SOURCE}/external/common/src/gtest" "${PROJECT_BUILD_TEMP_DIR}/lib" "${NTA_CXXFLAGS}")
 endif()
-
-#
-# Compile google test from source for linking with tests
-#
-set(LIB_STATIC_GTEST gtest)
-generate_static_library(${LIB_STATIC_GTEST} "${REPOSITORY_DIR}/extensions/core/external/common/src/gtest" "${PROJECT_BUILD_TEMP_DIR}/lib" "${NTA_CXXFLAGS}")
 
 #
 # HtmTest


### PR DESCRIPTION
This was causing builds to fail if re-using pre-built nupic.core.

cc @chetan51 
