### PR TITLE
Remove Python 2.6 from travis build matrix re: #1520

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,10 @@ env:
     - PATH=$TRAVIS_BUILD_DIR/python/bin:$PATH
   matrix:
     - PY_VER=2.7
-    - PY_VER=2.6
 
 matrix:
   # This excludes OSX builds from the build matrix for gcc and Python 2.6
   exclude:
-    - os: osx
-      env: PY_VER=2.6
     - os: osx
       compiler: gcc
 

--- a/ci/travis/install-linux.sh
+++ b/ci/travis/install-linux.sh
@@ -30,10 +30,6 @@ cmake --version
 # Verify python version
 python$PY_VER --version
 
-if [ $PY_VERSION != "2.7" ]; then
-   (cd nupic-linux64/ && mkdir -p lib/python${PY_VERSION}/site-packages && make)
-fi
-
 # Build NuPIC
 cd $NUPIC
 python$PY_VER setup.py install --user


### PR DESCRIPTION
Solution for https://github.com/numenta/nupic/issues/1520 that removes python 2.6 from the build matrix.  Merge on Tues. if no objections.
