### PR TITLE
Needed in order to make pip installable wheel

### DIFF
--- a/nupic/regions/UnimportableNode.py
+++ b/nupic/regions/UnimportableNode.py
@@ -1,6 +1,2 @@
-"""This file does NOT contain valid Python code. It is used to test
-error handling when trying to import "bad" Python nodes
+"""This file need only exist for testing purposes, and is not a valid region.
 """
-
-Try to
-interpreter...

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ import sys
 import os
 import subprocess
 from setuptools import setup
-import py_compile
 
 """
 This file only will call CMake process to generate scripts, build, and then
@@ -51,20 +50,6 @@ if len(sys.argv) == 1:
 version = None
 with open("VERSION", "r") as versionFile:
   version = versionFile.read().strip()
-
-# Replace py_compile.compile with a function that skips certain files that are meant to fail
-orig_py_compile = py_compile.compile
-
-PY_COMPILE_SKIP_FILES = [
-  "UnimportableNode.py",
-]
-
-
-def skip_py_compile(file, cfile=None, dfile=None, doraise=False):
-  if os.path.basename(file) not in PY_COMPILE_SKIP_FILES:
-    orig_py_compile(file, cfile=cfile, dfile=dfile, doraise=doraise)
-
-py_compile.compile = skip_py_compile
 
 
 def findPackages(repositoryDir):


### PR DESCRIPTION
In support of https://github.com/numenta/nupic/issues/1246

For whatever reason, the py_compile workaround in setup.py didn't apply when installing from wheel created with `python setup.py bdist_wheel` command.
