### PR TITLE
Pulling nupic.core binaries from S3 for builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,10 +138,10 @@ if("${NUPIC_CORE}" STREQUAL "")
   # User did not specify NUPIC_CORE binary location, assume relative to nupic
   set(NUPIC_CORE "${PROJECT_SOURCE_DIR}/extensions/core/build/release")
   set(NUPIC_CORE_SOURCE "${PROJECT_SOURCE_DIR}/extensions/core")
-  set(FETCH_NUPIC_CORE "TRUE")
+  set(FETCH_NUPIC_CORE TRUE)
 else()
   # User specified that they have their own nupic.core
-  set(FETCH_NUPIC_CORE "")
+  set(FETCH_NUPIC_CORE FALSE)
 endif()
 
 set(CMAKE_PREFIX_PATH ${NUPIC_CORE})


### PR DESCRIPTION
Fixes #1421.
## Use Case: Standard Build

To simulate, clean out any `nupic.core` artifacts:

```
rm -rf extensions/core
```

Installing will attempt to download a `nupic.core` binary from S3 based upon the host OS and `nupic.core` SHA specified in `.nupic_modules`. Binaries will be unpacked into `extensions/core/build/release` as the `bin`, `includes`, and `lib` directories. Build continues with these binaries in place, and `nupic.core` is not built locally.
### On download failure

To simulate a download failure, find the `NUPIC_CORE_BUCKET` variable in `CMakelists.txt` and screw it up. 

If there is a problem downloading the `nupic.core` package, the build will fallback to building `nupic.core` locally from the git checkout (this is the old process). The old logic stays in place here. The repo is cloned if necessary, or updated in place, then reset to the SHA specified in `.nupic_modules`.  
### When already downloaded

If a package file has already been downloaded, it will be used for the `nupic.core` binaries. To simulate this, simply install from scratch twice. On the second install, no download occurs. If the `nupic.core` SHA dependency changes, the new package will be downloaded on the next build.
## Use Case: Specified `nupic.core` binaries

If the users specifies a location for `nupic.core` binaries, fetching and building is bypassed entirely.

```
python setup.py install --user --cmake_options="-DNUPIC_CORE=${NUPIC_CORE}/build/release"
```

In this case, cmake will output a string like:

```
-- Using nupic.core binaries at /Users/mtaylor/nta/nupic.core/build/release
```

which indicates where `nupic.core` was used from. 
### Potential Issues
1. `nupic.core` packages are accumulated in `extensions/core/build/release` for re-use. There is currently no process to clean them up except for manual removal. 
2. If a local `nupic.core` package was already downloaded and exists, it is still unpacked (perhaps unnecessarily) once again... not a huge deal but costs a couple seconds. 
