### PR TITLE
Remove references to nupic.core unit tests (not explicitly part of nupic)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,23 +206,23 @@ if(FETCH_NUPIC_CORE)
     unpack_nupic_core("${NUPIC_CORE_SOURCE}" "${NUPIC_CORE_LOCAL_PACKAGE}")
   else()
     message(STATUS "Attempting to fetch nupic.core binaries from ${NUPIC_CORE_REMOTE_URL} and save to ${NUPIC_CORE_LOCAL_PACKAGE}...")
-    file(DOWNLOAD "${NUPIC_CORE_REMOTE_URL}" "${NUPIC_CORE_LOCAL_PACKAGE}" 
+    file(DOWNLOAD "${NUPIC_CORE_REMOTE_URL}" "${NUPIC_CORE_LOCAL_PACKAGE}"
       INACTIVITY_TIMEOUT 30
-      TIMEOUT 300 
-      STATUS "NUPIC_CORE_DOWNLOAD_STATUS" 
+      TIMEOUT 300
+      STATUS "NUPIC_CORE_DOWNLOAD_STATUS"
       SHOW_PROGRESS)
-    
-    # TODO: Give user a way to clean up all the downloaded binaries. It can be 
-    # manually done with `rm -rf ${NUPIC_CORE}/extensions/core` but would be 
+
+    # TODO: Give user a way to clean up all the downloaded binaries. It can be
+    # manually done with `rm -rf ${NUPIC_CORE}/extensions/core` but would be
     # cleaner with something like `python setup.py clean`.
-    
+
     if(NOT NUPIC_CORE_DOWNLOAD_STATUS EQUAL 0)
       message(WARNING "Error downloading nupic.core package: ${NUPIC_CORE_DOWNLOAD_STATUS}")
       message(STATUS "Building nupic.core from local checkout ${NUPIC_CORE_SOURCE}...")
       # Remove the local package file, which didn't get populated due to the
       # download failure.
       file(REMOVE "${NUPIC_CORE_LOCAL_PACKAGE}")
-      
+
       # Get nupic.core dependency through git.
       if (NOT(EXISTS "${NUPIC_CORE_SOURCE}/.git"))
         # There's not a git repo in NUPIC_CORE_SOURCE, so we can blow the whole
@@ -497,19 +497,9 @@ add_custom_target(tests_pyhtm
                   COMMAND testpyhtm
                   COMMENT "Basic tests in Python")
 
-add_custom_target(tests_cpphtm
-                  COMMAND testcpphtm
-                  COMMENT "Basic tests in C++")
-
-add_custom_target(cpp_unit_tests
-                  COMMAND unit_tests
-                  COMMENT "C++ unit tests")
-
 add_custom_target(tests_all
                   DEPENDS python_all_tests
                   DEPENDS tests_pyhtm
-                  DEPENDS tests_cpphtm
-                  DEPENDS cpp_unit_tests
                   COMMENT "Running all tests")
 
 #

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ![Numenta Logo](http://numenta.org/images/numenta-icon128.png) NuPIC
 
-## Numenta Platform for Intelligent Computing 
+## Numenta Platform for Intelligent Computing
 
 * Build: [![Build Status](https://travis-ci.org/numenta/nupic.png?branch=master)](https://travis-ci.org/numenta/nupic)
 * Unit Test Coverage: [![Coverage Status](https://coveralls.io/repos/numenta/nupic/badge.png?branch=master)](https://coveralls.io/r/numenta/nupic?branch=master)
 * [Regression Tests](https://github.com/numenta/nupic.regression): [![Build Status](https://travis-ci.org/numenta/nupic.regression.svg?branch=master)](https://travis-ci.org/numenta/nupic.regression)
- 
+
 NuPIC is a library that provides the building blocks for online prediction and anomaly detection systems.  The library contains the [Cortical Learning Algorithm (CLA)](https://github.com/numenta/nupic/wiki/Cortical-Learning-Algorithm), but also the [Online Prediction Framework (OPF)] (https://github.com/numenta/nupic/wiki/Online-Prediction-Framework) that allows clients to build prediction systems out of encoders, models, and metrics.
 
 For more information, see [numenta.org](http://numenta.org) or the [NuPIC wiki](https://github.com/numenta/nupic/wiki).
@@ -75,10 +75,6 @@ If you want develop, debug, or simply test NuPIC, clone it and follow the instru
 #### To run the tests:
 
     cd $NUPIC/build/scripts
-    # all C++ unit tests
-    make cpp_unit_tests
-    # C++ HTM Network API tests
-    make tests_cpphtm
     # Python HTM Network API tests
     make tests_pyhtm
     # Python OPF unit tests


### PR DESCRIPTION
No longer part of the nupic build.  Only works if the nupic.core tests are in path.

Thanks @lscheinkman 
