### PR TITLE
Added coverage==3.7.1 to external/common/requirements.txt because pytest...

### DIFF
--- a/external/common/requirements.txt
+++ b/external/common/requirements.txt
@@ -1,5 +1,6 @@
 #See http://www.pip-installer.org/en/latest/requirements.html for details
 asteval==0.9.1
+coverage==3.7.1
 mock==1.0.1
 ordereddict==1.1
 pillow==2.3.0


### PR DESCRIPTION
...-cov==1.6 fails to supply the necessary dependency on the coverage package.
