### PR TITLE
Clarify requirements and support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For all installation options, see the [Installing and Building NuPIC](https://gi
  * Make
  * CMake
 
-The dependencies are included in platform-specific repositories for convenience. Installing from these repositories is not required if the dependencies defined above have been manually installed or already exist on your system.
+The _python_ dependencies are included in platform-specific repositories for convenience. Installing from these repositories is not required if the dependencies defined above have been manually installed or already exist on your system.
 
 * [nupic-linux64](https://github.com/numenta/nupic-linux64) for 64-bit Linux systems
 * [nupic-darwin64](https://github.com/numenta/nupic-darwin64) for 64-bit OS X systems


### PR DESCRIPTION
I don't believe there is an issue that this solves, but I've noticed some recurring issues on the mailing list and other places regarding getting nupic up and running.  This is an attempt to remove the possibly misleading parts as well as clarify requirements.

No longer support python 2.6, and gcc needs to be 4.7 or greater in order to support c++11 features.  ARM support is misleading and full IDE support is sketchy (in my experience).
