### PR TITLE
Replace $NUPIC to ${TRAVIS_BUILD_DIR}

### DIFF
--- a/ci/travis/install-linux.sh
+++ b/ci/travis/install-linux.sh
@@ -31,7 +31,7 @@ cmake --version
 python --version
 
 # Build NuPIC
-cd $NUPIC
+cd ${TRAVIS_BUILD_DIR}
 python setup.py install --user
 
 # Show nupic installation folder by trying to import nupic, if works, it prints

--- a/ci/travis/install-osx.sh
+++ b/ci/travis/install-osx.sh
@@ -31,7 +31,7 @@ cmake --version
 python --version
 
 # Build NuPIC
-cd $NUPIC
+cd ${TRAVIS_BUILD_DIR}
 python setup.py install --user
 
 # Show nupic installation folder by trying to import nupic, if works, it prints

--- a/ci/travis/script-run-examples.sh
+++ b/ci/travis/script-run-examples.sh
@@ -24,21 +24,21 @@ echo
 echo Running script-run-examples.sh...
 echo
 
-python $NUPIC/examples/bindings/sparse_matrix_how_to.py || exit
-# python $NUPIC/examples/bindings/svm_how_to.py || exit # tkinter missing in Travis build machine
-# python $NUPIC/examples/bindings/temporal_pooler_how_to.py || exit # tkinter too
+python ${TRAVIS_BUILD_DIR}/examples/bindings/sparse_matrix_how_to.py || exit
+# python ${TRAVIS_BUILD_DIR}/examples/bindings/svm_how_to.py || exit # tkinter missing in Travis build machine
+# python ${TRAVIS_BUILD_DIR}/examples/bindings/temporal_pooler_how_to.py || exit # tkinter too
 
 # examples/opf (run at least 1 from each category)
-python $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/anomaly/spatial/2field_few_skewed/ || exit
-python $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/anomaly/temporal/saw_200/ || exit
-python $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/classification/category_TP_1/ || exit
-python $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/missing_record/simple_0/ || exit
-python $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/multistep/hotgym/ || exit
-python $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym_1hr_agg/ || exit
+python ${TRAVIS_BUILD_DIR}/scripts/run_opf_experiment.py ${TRAVIS_BUILD_DIR}/examples/opf/experiments/anomaly/spatial/2field_few_skewed/ || exit
+python ${TRAVIS_BUILD_DIR}/scripts/run_opf_experiment.py ${TRAVIS_BUILD_DIR}/examples/opf/experiments/anomaly/temporal/saw_200/ || exit
+python ${TRAVIS_BUILD_DIR}/scripts/run_opf_experiment.py ${TRAVIS_BUILD_DIR}/examples/opf/experiments/classification/category_TP_1/ || exit
+python ${TRAVIS_BUILD_DIR}/scripts/run_opf_experiment.py ${TRAVIS_BUILD_DIR}/examples/opf/experiments/missing_record/simple_0/ || exit
+python ${TRAVIS_BUILD_DIR}/scripts/run_opf_experiment.py ${TRAVIS_BUILD_DIR}/examples/opf/experiments/multistep/hotgym/ || exit
+python ${TRAVIS_BUILD_DIR}/scripts/run_opf_experiment.py ${TRAVIS_BUILD_DIR}/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym_1hr_agg/ || exit
 
 # opf/experiments/params - skip now
-python $NUPIC/scripts/run_opf_experiment.py $NUPIC/examples/opf/experiments/spatial_classification/category_1/ || exit
+python ${TRAVIS_BUILD_DIR}/scripts/run_opf_experiment.py ${TRAVIS_BUILD_DIR}/examples/opf/experiments/spatial_classification/category_1/ || exit
 
 # examples/tp
-python $NUPIC/examples/tp/hello_tp.py || exit
-python $NUPIC/examples/tp/tp_test.py || exit
+python ${TRAVIS_BUILD_DIR}/examples/tp/hello_tp.py || exit
+python ${TRAVIS_BUILD_DIR}/examples/tp/tp_test.py || exit


### PR DESCRIPTION
This PR aims remove $NUPIC env variable from Travis scripts in favor of the default ${TRAVIS_BUILD_DIR} special variable. One of the advantages is that travis scripts become more generic (which allows they be reused on other repositories).

CC: @oxtopus  @rhyolight 
