### PR TITLE
Using python wheels for binary packaging.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
 
 # Successful builds are archived and uploaded to S3 for regression testing.
 before_deploy:
-  - "if [ ${TRAVIS_OS_NAME:-'linux'} = 'linux' ]; then . ./ci/travis/before_deploy-linux.sh; fi"
+  - . ./ci/travis/before_deploy.sh
 
 deploy:
   provider: s3
@@ -34,10 +34,10 @@ deploy:
     secure: "ONG00ZCPpfU/nugFiON3K2q8IMk3nB/aAUj2Ggjf1z0CJS/cvnfIexmJhe+DJCccoco2l5gpiqp7gweH5vXEcyrzTt1I3Z+iFNas2cQ/wF3LjW0NcbdGeC9NN9kGIoOvr8g6L66CUvazYoirgbJO01ktm7LVNeGS3Q1pk36Vp10="
   bucket: artifacts.numenta.org
   region: us-west-2
-  local-dir: "dist"
+  local-dir: "dist/wheel"
   upload-dir: "numenta/nupic/${TRAVIS_COMMIT}"
   skip_cleanup: true
-  # Only deploy on master from one build job: linux, clang
+  # Only deploy on master from linux/clang job
   on:
     branch: master
     condition:

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -24,5 +24,13 @@ echo
 echo Running before_deploy-linux.sh...
 echo
 
+echo "sudo pip install wheel"
+sudo pip install wheel
+
 cd ${TRAVIS_BUILD_DIR}
-python setup.py bdist
+
+# Wheel fails unless we remove this.
+sudo rm -rf external/linux32arm
+
+echo "pip wheel --wheel-dir=dist/wheel -r external/common/requirements.txt ."
+pip wheel --wheel-dir=dist/wheel -r external/common/requirements.txt .


### PR DESCRIPTION
Switched from bdist deployment to wheels. Using wheels in attempt to
package nupic and dependencies and upload them all to S3. If this works,
I'll try to get regression tests installing from wheels before moving on
to OS X.
