### PR TITLE
Removing cython install before wheels build

### DIFF
--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -27,10 +27,6 @@ echo
 echo "sudo pip install wheel"
 sudo pip install wheel
 
-# pycapnp needs this for some reason.
-echo "sudo pip install cython"
-sudo pip install cython
-
 cd ${TRAVIS_BUILD_DIR}
 
 # Wheel fails unless we remove this.


### PR DESCRIPTION
This can be removed now that https://github.com/numenta/nupic/pull/1631 is merged. 
