### PR TITLE
Moving cython dependency to top of requirements.txt

### DIFF
--- a/external/common/requirements.txt
+++ b/external/common/requirements.txt
@@ -1,13 +1,13 @@
 #See http://www.pip-installer.org/en/latest/requirements.html for details
 # TODO: Remove setuptools/cython: https://github.com/jparyani/pycapnp/pull/36
 cython>=0.21
+setuptools>=0.8
 asteval==0.9.1
 coverage==3.7.1
 mock==1.0.1
 ordereddict==1.1
 pillow==2.3.0
 psutil==1.0.1
-setuptools>=0.8
 pycapnp==0.5.0
 pylint==1.1.0
 pytest==2.4.2


### PR DESCRIPTION
We're having problems with `pycapnp` requiring `cython`. For some reason in Grok pipelines, `cython` was not being installed before `pycapnp`. Trying to move to top of list to see if that helps. 
