### PR TITLE
pip requirements allow numpy>=1.7

### DIFF
--- a/external/common/requirements.txt
+++ b/external/common/requirements.txt
@@ -18,7 +18,7 @@ unittest2==0.5.1
 validictory==0.9.1
 PyMySQL==0.6.2
 DBUtils==1.1
-numpy==1.7.1
+numpy>=1.7.1
 tweepy==2.1
 pyproj==1.9.3
 prettytable==0.7.2


### PR DESCRIPTION
as a step to upgrading to numpy 1.9
part of #1516 
