### PR TITLE
Updates (manually) nupic.core to latest built SHA

### DIFF
--- a/.nupic_modules
+++ b/.nupic_modules
@@ -1,3 +1,3 @@
 # Default nupic.core dependencies (override in optional .nupic_config)
 NUPIC_CORE_REMOTE = 'git://github.com/numenta/nupic.core.git'
-NUPIC_CORE_COMMITISH = '52e7995d4638fbec192dea39fa1de6e84c6b6c14'
+NUPIC_CORE_COMMITISH = '743a7631fb8c16ed666dd1ce66becadbc5237ebd'


### PR DESCRIPTION
This PR is just to workaround the PR #1664 It points to my last commit (https://github.com/numenta/nupic.core/commit/743a7631fb8c16ed666dd1ce66becadbc5237ebd).
